### PR TITLE
Refactored PlayPublisherPlugin

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
@@ -12,7 +12,6 @@ class PlayPublisherPlugin implements Plugin<Project> {
         def log = project.logger
 
         def hasAppPlugin = project.plugins.find { p -> p instanceof AppPlugin }
-
         if (!hasAppPlugin) {
             throw new IllegalStateException("The 'com.android.application' plugin is required.")
         }
@@ -20,78 +19,72 @@ class PlayPublisherPlugin implements Plugin<Project> {
         def extension = project.extensions.create('play', PlayPublisherPluginExtension)
 
         project.android.applicationVariants.all { variant ->
-            def buildTypeName = variant.buildType.name.capitalize()
-
             if (!variant.buildType.name.equals("release")) {
                 log.debug("Skipping build type ${variant.buildType.name}.")
-                return;
+                return
             }
 
-            def projectFlavorNames = variant.productFlavors.collect { it.name.capitalize() }
+            def buildTypeName = variant.buildType.name.capitalize()
 
-            if (projectFlavorNames.isEmpty()) {
-                projectFlavorNames = [""]
+            def productFlavorNames = variant.productFlavors.collect { it.name.capitalize() }
+            if (productFlavorNames.isEmpty()) {
+                productFlavorNames = [""]
+            }
+            def productFlavorName = productFlavorNames.join('')
+            def flavor = StringUtils.uncapitalize(productFlavorName)
+
+            def variationName = "${productFlavorName}${buildTypeName}"
+
+            def zipalignTaskName = "zipalign${variationName}"
+            def manifestTaskName = "process${variationName}Manifest"
+            def assembleTaskName = "assemble${variationName}"
+            def playResourcesTaskName = "generate${variationName}PlayResources"
+            def publishApkTaskName = "publishApk${variationName}"
+            def publishListingTaskName = "publishListing${variationName}"
+            def publishTaskName = "publish${variationName}"
+
+            def variantData = variant.variantData
+
+            if (!variantData.zipAlign) {
+                log.info("Could not find ZipAlign task. Did you specify a signingConfig for the variation ${variationName}?")
+                return
             }
 
-            def projectFlavorName = projectFlavorNames.join('')
+            // Find Android tasks to use their outputs.
+            def zipalignTask = project.tasks."$zipalignTaskName"
+            def manifestTask = project.tasks."$manifestTaskName"
+            def assembleTask = project.tasks."$assembleTaskName"
 
-            def zipalignTaskName = "zipalign$projectFlavorName$buildTypeName"
-            def manifestTaskName = "process${projectFlavorName}${buildTypeName}Manifest"
-            def playResourcesTaskName = "generate${projectFlavorName}${buildTypeName}PlayResources"
-            def publishApkTaskName = "publishApk$projectFlavorName$buildTypeName"
-            def publishListingTaskName = "publishListing$projectFlavorName$buildTypeName"
-            def publishTaskName = "publish$projectFlavorName$buildTypeName"
-
-            try {
-                // Find Android tasks to use their outputs.
-                def zipalignTask = project.tasks."$zipalignTaskName"
-                def manifestTask = project.tasks."$manifestTaskName"
-
-                // Create task to collect the play store resources.
-                def playResourcesTask = project.tasks.create(playResourcesTaskName, GeneratePlayResourcesTask)
-
-                // Configure the inputs and outputs
-                def configurations = []
-                configurations << "main"
-
-                def flavor = StringUtils.uncapitalize(projectFlavorName)
-                if (!StringUtils.isEmpty(flavor)) {
-                    configurations << flavor
-                }
-                configurations.each { c ->
-                    playResourcesTask.inputs.file(new File(project.getProjectDir(), "src/${c}/play"))
-                }
-
-                def playResourcesOutput = new File(project.getProjectDir(), "build/outputs/play/${variant.name}")
-                playResourcesTask.outputFolder = playResourcesOutput
-
-                // Create and configure publisher apk task for this variant.
-                def publishApkTask = project.tasks.create(publishApkTaskName, PlayPublishApkTask)
-                publishApkTask.extension = extension
-                publishApkTask.apkFile = zipalignTask.outputFile
-                publishApkTask.manifestFile = manifestTask.manifestOutputFile
-                publishApkTask.inputFolder = playResourcesTask.outputFolder
-
-                // Create and configure publisher meta task for this variant
-                def publishListingTask = project.tasks.create(publishListingTaskName, PlayPublishListingTask)
-                publishListingTask.extension = extension
-                publishListingTask.manifestFile = manifestTask.manifestOutputFile
-                publishListingTask.inputFolder = playResourcesTask.outputFolder
-
-                def publishTask = project.tasks.create(publishTaskName)
-
-                // Attach tasks to task graph.
-                publishTask.dependsOn publishApkTask
-                publishTask.dependsOn publishListingTask
-                publishListingTask.dependsOn playResourcesTask
-                publishListingTask.dependsOn manifestTask
-                publishApkTask.dependsOn playResourcesTask
-                publishApkTask.dependsOn project.tasks."assemble$projectFlavorName$buildTypeName"
-
-            } catch (MissingPropertyException e) {
-                log.info("Could not find task ${zipalignTaskName}. Did you specify a signinConfig for the variation $projectFlavorName$buildTypeName?")
+            // Create and configure task to collect the play store resources.
+            def playResourcesTask = project.tasks.create(playResourcesTaskName, GeneratePlayResourcesTask)
+            playResourcesTask.inputs.file(new File(project.getProjectDir(), "src/main/play"))
+            if (StringUtils.isNotEmpty(flavor)) {
+                playResourcesTask.inputs.file(new File(project.getProjectDir(), "src/${flavor}/play"))
             }
+            playResourcesTask.outputFolder = new File(project.getProjectDir(), "build/outputs/play/${variant.name}")
 
+            // Create and configure publisher apk task for this variant.
+            def publishApkTask = project.tasks.create(publishApkTaskName, PlayPublishApkTask)
+            publishApkTask.extension = extension
+            publishApkTask.apkFile = zipalignTask.outputFile
+            publishApkTask.manifestFile = manifestTask.manifestOutputFile
+            publishApkTask.inputFolder = playResourcesTask.outputFolder
+
+            // Create and configure publisher meta task for this variant
+            def publishListingTask = project.tasks.create(publishListingTaskName, PlayPublishListingTask)
+            publishListingTask.extension = extension
+            publishListingTask.manifestFile = manifestTask.manifestOutputFile
+            publishListingTask.inputFolder = playResourcesTask.outputFolder
+
+            def publishTask = project.tasks.create(publishTaskName)
+
+            // Attach tasks to task graph.
+            publishTask.dependsOn publishApkTask
+            publishTask.dependsOn publishListingTask
+            publishListingTask.dependsOn playResourcesTask
+            publishListingTask.dependsOn manifestTask
+            publishApkTask.dependsOn playResourcesTask
+            publishApkTask.dependsOn assembleTask
         }
     }
 


### PR DESCRIPTION
- Use variant.zipAlign instead of try-catch.
- Refactored creation of inputs for PlayResourcesTask.
- DRY: Defined and reused variationName.

/cc @bhurling 
