### PR TITLE
Removed all @Input and @Output annotations

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/BootstrapTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/BootstrapTask.groovy
@@ -5,7 +5,6 @@ import com.google.api.services.androidpublisher.model.ApkListing
 import com.google.api.services.androidpublisher.model.Image
 import com.google.api.services.androidpublisher.model.Listing
 import org.apache.commons.io.FileUtils
-import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 class BootstrapTask extends PlayPublishTask {
@@ -19,7 +18,6 @@ class BootstrapTask extends PlayPublishTask {
             PlayPublishListingTask.IMAGE_TYPE_PROMO_GRAPHIC
     ]
 
-    @OutputDirectory
     File outputFolder
 
     @TaskAction

--- a/src/main/groovy/de/triplet/gradle/play/GeneratePlayResourcesTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/GeneratePlayResourcesTask.groovy
@@ -2,12 +2,10 @@ package de.triplet.gradle.play
 
 import org.apache.commons.io.FileUtils
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 class GeneratePlayResourcesTask extends DefaultTask {
 
-    @OutputDirectory
     File outputFolder;
 
     @TaskAction

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishApkTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishApkTask.groovy
@@ -4,8 +4,6 @@ import com.google.api.client.http.FileContent
 import com.google.api.services.androidpublisher.model.Apk
 import com.google.api.services.androidpublisher.model.ApkListing
 import com.google.api.services.androidpublisher.model.Track
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
 
 class PlayPublishApkTask extends PlayPublishTask {
@@ -13,10 +11,8 @@ class PlayPublishApkTask extends PlayPublishTask {
     static def MAX_CHARACTER_LENGTH_FOR_WHATS_NEW_TEXT = 500
     static def FILE_NAME_FOR_WHATS_NEW_TEXT = "whatsnew"
 
-    @Input
     File apkFile
 
-    @InputDirectory
     File inputFolder
 
     @TaskAction

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishListingTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishListingTask.groovy
@@ -4,7 +4,6 @@ import com.google.api.client.http.AbstractInputStreamContent
 import com.google.api.services.androidpublisher.AndroidPublisher
 import com.google.api.services.androidpublisher.model.Listing
 import org.apache.commons.lang.StringUtils
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
 
 class PlayPublishListingTask extends PlayPublishTask {
@@ -26,7 +25,6 @@ class PlayPublishListingTask extends PlayPublishTask {
     static def IMAGE_TYPE_SEVEN_INCH_SCREENSHOTS = "sevenInchScreenshots"
     static def IMAGE_TYPE_TEN_INCH_SCREENSHOTS = "tenInchScreenshots"
 
-    @InputDirectory
     File inputFolder
 
     @TaskAction

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishTask.groovy
@@ -3,17 +3,14 @@ package de.triplet.gradle.play
 import com.google.api.services.androidpublisher.AndroidPublisher
 import com.google.api.services.androidpublisher.model.AppEdit
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.Input
 
 class PlayPublishTask extends DefaultTask {
 
     // region '419' is a special case in the play store that represents latin america
     def matcher = ~"^[a-z]{2}(-([A-Z]{2}|419))?\\z"
 
-    @Input
     PlayPublisherPluginExtension extension
 
-    @Input
     String applicationId
 
     String editId
@@ -36,10 +33,6 @@ class PlayPublishTask extends DefaultTask {
         AppEdit edit = editRequest.execute()
 
         editId = edit.getId()
-    }
-
-    void setExtension(PlayPublisherPluginExtension extension) {
-        this.extension = extension
     }
 
 }


### PR DESCRIPTION
They could lead to unwanted UP-TO-DATE states:

First run will be executed as expected:

```
$ gradle bootstrapReleasePlayResources
:bootstrapReleasePlayResources

BUILD SUCCESSFUL

Total time: 22.356 secs
```

The second run simply states `UP-TO-DATE` and returns without doing anything:

```
$ gradle bootstrapReleasePlayResources
:bootstrapReleasePlayResources UP-TO-DATE

BUILD SUCCESSFUL

Total time: 14.683 secs
```

/cc @bhurling
