### PR TITLE
Includes src/<buildType.name>/play as place for resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To use this feature, create a special source folder called ```play```. Inside, c
 ```
 Note: Make sure your texts comply to the requirements of the Play Store, that is they do not exceed the allowed lengths of *30 characters* for the title, *80 characters* for the short description, *4000 characters* for the description and *500 characters* for the summary of recent changes.
 
-Note: You can provide different texts for different locales and product flavors. You may even support additional locales for some product flavors.
+Note: You can provide different texts for different locales, build types and product flavors. You may even support additional locales for some build types or product flavors.
 
 ### Specify the track
 

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
@@ -61,7 +61,7 @@ class PlayPublisherPlugin implements Plugin<Project> {
             if (StringUtils.isNotEmpty(flavor)) {
                 bootstrapTask.outputFolder = new File(project.getProjectDir(), "src/${flavor}/play")
             } else {
-                bootstrapTask.outputFolder = new File(project.getProjectDir(), "src/main/play")
+                bootstrapTask.outputFolder = new File(project.getProjectDir(), "src/${variant.buildType.name}/play")
             }
             bootstrapTask.description = "Downloads the play store listing for the ${variationName} build. No download of image resources. See #18."
             bootstrapTask.group = PLAY_STORE_GROUP
@@ -69,6 +69,7 @@ class PlayPublisherPlugin implements Plugin<Project> {
             // Create and configure task to collect the play store resources.
             def playResourcesTask = project.tasks.create(playResourcesTaskName, GeneratePlayResourcesTask)
             playResourcesTask.inputs.file(new File(project.getProjectDir(), "src/main/play"))
+            playResourcesTask.inputs.file(new File(project.getProjectDir(), "src/${variant.buildType.name}/play"))
             if (StringUtils.isNotEmpty(flavor)) {
                 playResourcesTask.inputs.file(new File(project.getProjectDir(), "src/${flavor}/play"))
             }


### PR DESCRIPTION
After the change included from https://github.com/Triple-T/gradle-play-publisher/pull/37 (which is great :+1: ) I think it makes sense to extend it by including **src/\<buildType.name\>/play** as another place to look for play resources. That would be very convenient for projects like this:

```groovy
buildTypes {
    debug {
       applicationIdSuffix '.debug'
       versionNameSuffix " DEBUG"
    }

    release {
        minifyEnabled true
        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
        signingConfig signingConfigs.release
    }

    dogfood.initWith(buildTypes.release)
    dogfood {
        applicationIdSuffix '.dogfood'
        versionNameSuffix " DOGFOOD"
    }
}
```

For publishing a **dogfood** or **release** build version into Google Play it seems more appropriate to include play resources under **src/dogfood/play** or **src/release/play** rather than **src/main/play**.