### PR TITLE
Defer applicationId retrieval to when the publish task runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: android
 
 android:
   components:
-    - build-tools-21.1.2
-    - android-21
+    - build-tools-22.0.1
+    - android-22
 
 script:
   - ./gradlew check --stacktrace

--- a/src/main/groovy/de/triplet/gradle/play/BootstrapTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/BootstrapTask.groovy
@@ -30,7 +30,7 @@ class BootstrapTask extends PlayPublishTask {
 
     def bootstrapListing() {
         List<Listing> listings = edits.listings()
-                .list(applicationId, editId)
+                .list(variant.getApplicationId(), editId)
                 .execute()
                 .getListings()
         if (listings == null) {
@@ -60,7 +60,7 @@ class BootstrapTask extends PlayPublishTask {
 
             for (String imageType : IMAGE_TYPE_ARRAY) {
                 List<Image> images = edits.images()
-                        .list(applicationId, editId, language, imageType)
+                        .list(variant.getApplicationId(), editId, language, imageType)
                         .execute()
                         .getImages()
                 saveImage(listingDir, imageType, images)
@@ -74,7 +74,7 @@ class BootstrapTask extends PlayPublishTask {
 
     def bootstrapWhatsNew() {
         List<Apk> apks = edits.apks()
-                .list(applicationId, editId)
+                .list(variant.getApplicationId(), editId)
                 .execute()
                 .getApks()
         if (apks == null) {
@@ -83,7 +83,7 @@ class BootstrapTask extends PlayPublishTask {
         Integer versionCode = apks.collect { apk -> apk.getVersionCode() }.max()
 
         List<ApkListing> apkListings = edits.apklistings()
-                .list(applicationId, editId, versionCode)
+                .list(variant.getApplicationId(), editId, versionCode)
                 .execute()
                 .getListings()
         if (apkListings == null) {

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishApkTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishApkTask.groovy
@@ -1,7 +1,5 @@
 package de.triplet.gradle.play
-
 import com.android.build.gradle.api.ApkVariantOutput
-import com.android.build.gradle.api.ApplicationVariant
 import com.google.api.client.http.FileContent
 import com.google.api.services.androidpublisher.model.Apk
 import com.google.api.services.androidpublisher.model.ApkListing
@@ -13,8 +11,6 @@ class PlayPublishApkTask extends PlayPublishTask {
     static def MAX_CHARACTER_LENGTH_FOR_WHATS_NEW_TEXT = 500
     static def FILE_NAME_FOR_WHATS_NEW_TEXT = "whatsnew"
 
-    ApplicationVariant variant
-
     File inputFolder
 
     @TaskAction
@@ -25,12 +21,12 @@ class PlayPublishApkTask extends PlayPublishTask {
         FileContent newApkFile = new FileContent(AndroidPublisherHelper.MIME_TYPE_APK, apkOutput.outputFile)
 
         Apk apk = edits.apks()
-                .upload(applicationId, editId, newApkFile)
+                .upload(variant.getApplicationId(), editId, newApkFile)
                 .execute()
 
         Track newTrack = new Track().setVersionCodes([apk.getVersionCode()])
         edits.tracks()
-                .update(applicationId, editId, extension.track, newTrack)
+                .update(variant.getApplicationId(), editId, extension.track, newTrack)
                 .execute()
 
         if (inputFolder.exists()) {
@@ -49,14 +45,14 @@ class PlayPublishApkTask extends PlayPublishTask {
 
                     ApkListing newApkListing = new ApkListing().setRecentChanges(whatsNewText)
                     edits.apklistings()
-                            .update(applicationId, editId, apk.getVersionCode(), locale, newApkListing)
+                            .update(variant.getApplicationId(), editId, apk.getVersionCode(), locale, newApkListing)
                             .execute()
                 }
             }
 
         }
 
-        edits.commit(applicationId, editId).execute()
+        edits.commit(variant.getApplicationId(), editId).execute()
     }
 
 }

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishListingTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishListingTask.groovy
@@ -61,7 +61,7 @@ class PlayPublishListingTask extends PlayPublishTask {
 
                 try {
                     edits.listings()
-                            .update(applicationId, editId, locale, listing)
+                            .update(variant.getApplicationId(), editId, locale, listing)
                             .execute()
                 } catch (GoogleJsonResponseException e) {
 
@@ -104,7 +104,7 @@ class PlayPublishListingTask extends PlayPublishTask {
             }
         }
 
-        edits.commit(applicationId, editId).execute()
+        edits.commit(variant.getApplicationId(), editId).execute()
     }
 
     def uploadSingleGraphic(AbstractInputStreamContent contentGraphic, String locale, String imageType) {
@@ -112,10 +112,10 @@ class PlayPublishListingTask extends PlayPublishTask {
             AndroidPublisher.Edits.Images images = edits.images()
 
             // Delete current image in play store
-            images.deleteall(applicationId, editId, locale, imageType).execute()
+            images.deleteall(variant.getApplicationId(), editId, locale, imageType).execute()
 
             // After that upload the new image
-            images.upload(applicationId, editId, locale, imageType, contentGraphic).execute()
+            images.upload(variant.getApplicationId(), editId, locale, imageType, contentGraphic).execute()
         }
     }
 
@@ -124,14 +124,14 @@ class PlayPublishListingTask extends PlayPublishTask {
             AndroidPublisher.Edits.Images images = edits.images()
 
             // Delete all images in play store
-            images.deleteall(applicationId, editId, locale, imageType).execute()
+            images.deleteall(variant.getApplicationId(), editId, locale, imageType).execute()
 
             // After that upload the new images
             if (contentGraphicList.size() > MAX_SCREENSHOTS_SIZE) {
                 logger.error("Sorry! You can only upload 8 screenshots")
             } else {
                 contentGraphicList.each { contentGraphic ->
-                    images.upload(applicationId, editId, locale, imageType, contentGraphic).execute()
+                    images.upload(variant.getApplicationId(), editId, locale, imageType, contentGraphic).execute()
                 }
             }
         }

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishTask.groovy
@@ -1,5 +1,6 @@
 package de.triplet.gradle.play
 
+import com.android.build.gradle.api.ApplicationVariant
 import com.google.api.services.androidpublisher.AndroidPublisher
 import com.google.api.services.androidpublisher.model.AppEdit
 import org.gradle.api.DefaultTask
@@ -11,7 +12,7 @@ class PlayPublishTask extends DefaultTask {
 
     PlayPublisherPluginExtension extension
 
-    String applicationId
+    ApplicationVariant variant
 
     String editId
 
@@ -28,7 +29,7 @@ class PlayPublishTask extends DefaultTask {
 
         // Create a new edit to make changes to your listing.
         AndroidPublisher.Edits.Insert editRequest = edits.insert(
-                applicationId,
+                variant.getApplicationId(),
                 null /* no content yet */)
         AppEdit edit = editRequest.execute()
 

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
@@ -36,7 +36,6 @@ class PlayPublisherPlugin implements Plugin<Project> {
             def flavor = StringUtils.uncapitalize(productFlavorName)
 
             def variationName = "${productFlavorName}${buildTypeName}"
-            def variantApplicationId = variant.applicationId
 
             def bootstrapTaskName = "bootstrap${variationName}PlayResources"
             def playResourcesTaskName = "generate${variationName}PlayResources"
@@ -57,7 +56,7 @@ class PlayPublisherPlugin implements Plugin<Project> {
             // Create and configure bootstrap task for this variant.
             def bootstrapTask = project.tasks.create(bootstrapTaskName, BootstrapTask)
             bootstrapTask.extension = extension
-            bootstrapTask.applicationId = variantApplicationId
+            bootstrapTask.variant = variant
             if (StringUtils.isNotEmpty(flavor)) {
                 bootstrapTask.outputFolder = new File(project.getProjectDir(), "src/${flavor}/play")
             } else {
@@ -86,7 +85,6 @@ class PlayPublisherPlugin implements Plugin<Project> {
             def publishApkTask = project.tasks.create(publishApkTaskName, PlayPublishApkTask)
             publishApkTask.extension = extension
             publishApkTask.variant = variant
-            publishApkTask.applicationId = variantApplicationId
             publishApkTask.inputFolder = playResourcesTask.outputFolder
             publishApkTask.description = "Uploads the APK for the ${variationName} build"
             publishApkTask.group = PLAY_STORE_GROUP
@@ -94,7 +92,7 @@ class PlayPublisherPlugin implements Plugin<Project> {
             // Create and configure publisher meta task for this variant
             def publishListingTask = project.tasks.create(publishListingTaskName, PlayPublishListingTask)
             publishListingTask.extension = extension
-            publishListingTask.applicationId = variantApplicationId
+            publishListingTask.variant = variant
             publishListingTask.inputFolder = playResourcesTask.outputFolder
             publishListingTask.description = "Updates the play store listing for the ${variationName} build"
             publishListingTask.group = PLAY_STORE_GROUP

--- a/src/test/groovy/de/triplet/gradle/play/TestHelper.groovy
+++ b/src/test/groovy/de/triplet/gradle/play/TestHelper.groovy
@@ -12,14 +12,14 @@ public class TestHelper {
         project.apply plugin: 'com.android.application'
         project.apply plugin: 'play'
         project.android {
-            compileSdkVersion 21
-            buildToolsVersion '21.1.2'
+            compileSdkVersion 22
+            buildToolsVersion '22.0.1'
 
             defaultConfig {
                 versionCode 1
                 versionName '1.0'
-                minSdkVersion 21
-                targetSdkVersion 21
+                minSdkVersion 22
+                targetSdkVersion 22
             }
 
             buildTypes {


### PR DESCRIPTION
This should resolve #54 

This removes the `applicationId` field entirely from `PlayPublishTask` and instead keeps a `variant` field. This way, the applicationId retrieval can wait until the task actually runs, allowing for any user change to the applicationId during project configuration without causing the upload to fail later due to an out-of-date applicationId.

I've added a test as well. Please let me know if I should change/improve/fix it in anyway, as I haven't written a test for groovy before.