### PR TITLE
Fetch version codes for each track during bootstrapPlayResources task

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/BootstrapTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/BootstrapTask.groovy
@@ -4,6 +4,7 @@ import com.google.api.services.androidpublisher.model.Apk
 import com.google.api.services.androidpublisher.model.ApkListing
 import com.google.api.services.androidpublisher.model.Image
 import com.google.api.services.androidpublisher.model.Listing
+import com.google.api.services.androidpublisher.model.Track
 import org.apache.commons.io.FileUtils
 import org.gradle.api.tasks.TaskAction
 
@@ -42,6 +43,11 @@ class BootstrapTask extends PlayPublishTask {
         String shortDescription
         String title
         String video
+
+        edits.tracks().list(variant.getApplicationId(), editId).execute().tracks.each { Track track ->
+            FileUtils.writeStringToFile(new File(outputFolder,
+                    "${PlayPublishListingTask.FILE_NAME_FOR_VERSION}-${track.track}"), track.versionCodes.join(','), 'UTF-8')
+        }
 
         for (Listing listing : listings) {
             language = listing.getLanguage()

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishListingTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishListingTask.groovy
@@ -18,6 +18,7 @@ class PlayPublishListingTask extends PlayPublishTask {
     static def FILE_NAME_FOR_SHORT_DESCRIPTION = "shortdescription"
     static def FILE_NAME_FOR_FULL_DESCRIPTION = "fulldescription"
     static def FILE_NAME_FOR_VIDEO = "video"
+    static def FILE_NAME_FOR_VERSION = "version"
     static def LISTING_PATH = "listing/"
 
     static def IMAGE_TYPE_FEATURE_GRAPHIC = "featureGraphic"


### PR DESCRIPTION
My use-case is the following: I maintain an app with about 70 flavors and all these are not kept at the same version (depends on server-side software among other things). Before I push an update I need to know which version the app currently has so I can pull the relevant "What's new". With this addition I can do this automatically.

This addition saves the version code(s) for each track in a file called version-\<track\> in the play-directory during the bootstrapPlayResources task. For multi-apk apps the version codes are written comma-separated.

Would it be desired to wrap it in a config if the extra files are unwanted?