### PR TITLE
Updated AndroidPublisher dependency from rev16-1.19.1 to rev18-1.20.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile gradleApi()
 
     compile 'com.android.tools.build:gradle:1.1.3'
-    compile('com.google.apis:google-api-services-androidpublisher:v2-rev16-1.19.1') {
+    compile('com.google.apis:google-api-services-androidpublisher:v2-rev18-1.20.0') {
         exclude group: 'com.google.guava', module: 'guava-jdk5'
     }
     compile 'commons-lang:commons-lang:2.6'


### PR DESCRIPTION
Unfortunately I was unable to find a changelog or release notes, so it's up to you if this gets merged in.