### PR TITLE
Triple-T/gradle-play-publisher#44 fixes "403 : invalidAppContactPhone…

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishListingTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishListingTask.groovy
@@ -140,7 +140,7 @@ class PlayPublishListingTask extends PlayPublishTask {
 
             details.setContactEmail(email)
                     .setContactPhone(phone)
-                    .setContactPhone(web)
+                    .setContactWebsite(web)
                     .setDefaultLanguage(defaultLanguage)
 
             edits.details()


### PR DESCRIPTION
…" set "set Contact Website" to ContactWebsite property but not to ContactPhone property.