### PR TITLE
Made signingConfig not require for bootstrapping and lisitng tasks

### DIFF
--- a/src/test/groovy/de/triplet/gradle/play/PlayPublisherPluginTest.groovy
+++ b/src/test/groovy/de/triplet/gradle/play/PlayPublisherPluginTest.groovy
@@ -7,6 +7,7 @@ import org.junit.Test
 
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.fail
 
 class PlayPublisherPluginTest {
 
@@ -100,6 +101,20 @@ class PlayPublisherPluginTest {
 
         assertNotNull(project.tasks.publishListingFreeRelease)
         assertNotNull(project.tasks.publishListingPaidRelease)
+    }
+
+    @Test
+    public void testNoSigningConfigGenerateTasks() {
+        Project project = TestHelper.noSigningConfigProject()
+
+        project.evaluate()
+
+        assertNotNull(project.tasks.bootstrapReleasePlayResources)
+        assertNotNull(project.tasks.publishListingRelease)
+
+        if (project.tasks.hasProperty('publishApkRelease') || project.tasks.hasProperty('publishRelease')) {
+            fail()
+        }
     }
 
 }

--- a/src/test/groovy/de/triplet/gradle/play/TestHelper.groovy
+++ b/src/test/groovy/de/triplet/gradle/play/TestHelper.groovy
@@ -31,4 +31,28 @@ public class TestHelper {
 
         return project
     }
+
+    public static Project noSigningConfigProject() {
+        Project project = ProjectBuilder.builder().withProjectDir(FIXTURE_WORKING_DIR).build()
+        project.apply plugin: 'com.android.application'
+        project.apply plugin: 'com.github.triplet.play'
+        project.android {
+            compileSdkVersion 22
+            buildToolsVersion '22.0.1'
+
+            defaultConfig {
+                versionCode 1
+                versionName '1.0'
+                minSdkVersion 22
+                targetSdkVersion 22
+            }
+
+            buildTypes {
+                release {
+                }
+            }
+        }
+
+        return project
+    }
 }


### PR DESCRIPTION
see #100 

~~I assumed if there are no signingConfig, throw `IllegalArgumentException`. If you don't want to create the publishApk task names, let me know. I will put the validation back to `PlayPublisherPlugin`.~~