### PR TITLE
Autoincrement of the version

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/LatestVersionCodeTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/LatestVersionCodeTask.groovy
@@ -1,0 +1,34 @@
+package de.triplet.gradle.play
+
+import com.android.build.gradle.api.ApplicationVariant
+import com.android.builder.model.SigningConfig
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
+import com.google.api.services.androidpublisher.AndroidPublisher
+import com.google.api.services.androidpublisher.model.AppEdit
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+class LatestVersionCodeTask extends PlayPublishTask {
+
+    @TaskAction
+    updateVersion(){
+        try {
+            publish()
+            // Get a list of apks.
+            def apksResponse = edits.apks()
+                    .list(variant.applicationId, editId)
+                    .execute()
+            //Get latest apk (at least one apk should be there, otherwise it will throw an exception earlier)
+            def apk = apksResponse.apks.last()
+
+            //delete latest edit
+            edits.delete(variant.applicationId, editId).execute()
+
+            variant.mergedFlavor.versionCode =  apk.versionCode + 1
+
+        } catch (IllegalArgumentException|GoogleJsonResponseException ex){
+            logger.debug("exception ignored", ex)
+        }
+        logger.debug("Version set to " + variant.mergedFlavor.versionCode)
+    }
+}

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
@@ -42,6 +42,7 @@ class PlayPublisherPlugin implements Plugin<Project> {
             def publishApkTaskName = "publishApk${variationName}"
             def publishListingTaskName = "publishListing${variationName}"
             def publishTaskName = "publish${variationName}"
+            def updatePlayVersionName = "update${variationName}PlayVersion"
 
             def outputData = variant.outputs.first()
             def zipAlignTask = outputData.zipAlign
@@ -100,6 +101,18 @@ class PlayPublisherPlugin implements Plugin<Project> {
                 def publishTask = project.tasks.create(publishTaskName)
                 publishTask.description = "Updates APK and play store listing for the ${variationName} build"
                 publishTask.group = PLAY_STORE_GROUP
+
+                if (extension.autoIncrementVersion) {
+                    def updatePlayVersionTask = project.tasks.create(updatePlayVersionName, LatestVersionCodeTask)
+                    updatePlayVersionTask.description = "Gets the latest version code from play store for ${variationName} build and sets the next one"
+                    updatePlayVersionTask.group = PLAY_STORE_GROUP
+                    updatePlayVersionTask.extension = extension
+                    updatePlayVersionTask.variant = variant
+
+                    variant.preBuild.doLast {
+                        updatePlayVersionTask.updateVersion()
+                    }
+                }
 
                 // Attach tasks to task graph.
                 publishTask.dependsOn publishApkTask

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPluginExtension.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPluginExtension.groovy
@@ -12,6 +12,8 @@ class PlayPublisherPluginExtension {
 
     boolean errorOnSizeLimit = true
 
+    boolean autoIncrementVersion = false
+
     private String track = 'alpha'
 
     void setTrack(String track) {


### PR DESCRIPTION
Hi, 
This code adds an option to assign the proper versionCode to a build before release, based on a last version code in the play store  (basically, it's gets the latest apk's versionCode and increments it by 1).
Looks like it's a typical problem for ones who try to do daily builds. Usually it's solved by storing the counter in file next to the code, but this solution is much better if you distribute builds over play store. 
Are you interested in such feature? 
