### PR TITLE
Untrack application in alpha when deploying to beta

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishApkTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishApkTask.groovy
@@ -32,6 +32,12 @@ class PlayPublishApkTask extends PlayPublishTask {
         edits.tracks()
                 .update(variant.applicationId, editId, extension.track, newTrack)
                 .execute()
+        if (extension.track?.equals("beta")) {
+          Track emptyTrack = new Track().setVersionCodes([])
+          edits.tracks()
+                  .update(variant.applicationId, editId, 'alpha', emptyTrack)
+                  .execute();
+        }
 
         if (inputFolder.exists()) {
 


### PR DESCRIPTION
To allow us to publish to beta when we have app active in alpha,
I remove the tracking of the app from alpha after successful
update on beta channel.