### PR TITLE
allow to provide p12 password

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPluginExtension.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPluginExtension.groovy
@@ -5,6 +5,10 @@ class PlayPublisherPluginExtension {
     String serviceAccountEmail
 
     File pk12File
+    String pk12Password
+    String storePassword
+    String keyAlias
+    String keyPassword
 
     File jsonFile
 


### PR DESCRIPTION
This pull request allows to provide a custom p12 password, either with

```
play {
    serviceAccountEmail 'service'
    pk12File file('file.p12')
    pk12Password 'asecret'
}
```

(using password for both store & key, and using default `privatekey` alias)

or more customised

```
play {
    serviceAccountEmail 'service'
    pk12File file('file.p12')
    storePassword 'storepass'
    keyAlias 'keyalias'
    keyPassword 'keypass'
}
```
