### PR TITLE
Adding a clarification of the userFraction param in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ As a default your APK is published to the alpha track and you can promote it to 
 play {
     // ...
     track = 'production' // or 'rollout' or 'beta' or 'alpha'
-    userFraction = 0.2 // only necessary for 'rollout', in this case default is 0.1
+    userFraction = 0.2 // only necessary for 'rollout', in this case default is 0.1 (10% of the target)
 }
 ```
 


### PR DESCRIPTION
Following the readme, I've seen that the default userFraction was 0.1. I thought it was a porcentage, like in the Google Play environment. But 1 meant 100%, not 1%... so I propose to add this small clarification, to avoid doing the mistake of publishing a version at 50% instead of 0.5%, as I did :·)