### PR TITLE
Fix character counting

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/TaskHelper.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/TaskHelper.groovy
@@ -7,18 +7,25 @@ class TaskHelper {
 
     def static readAndTrimFile(File file, int maxCharLength, boolean errorOnSizeLimit) {
         if (file.exists()) {
-            def message = file.text
-            if (message.length() > maxCharLength) {
-                if (errorOnSizeLimit) {
-                    throw new LimitExceededException(file, maxCharLength)
-                }
-
-                return message.substring(0, maxCharLength)
-            }
-            return message
+            def text = file.text
+            return normalizeAndTrimText(file, text, maxCharLength, errorOnSizeLimit)
         }
 
         return ""
+    }
+
+    static String normalizeAndTrimText(File file, String text, int maxCharLength, boolean errorOnSizeLimit) {
+        def message = text.replaceAll("\\r\\n", "\n")
+
+        if (message.length() > maxCharLength) {
+            if (errorOnSizeLimit) {
+                throw new LimitExceededException(file, maxCharLength)
+            }
+
+            return message.substring(0, maxCharLength)
+        }
+
+        return message
     }
 
     def static List<AbstractInputStreamContent> getImageListAsStream(File listingDir, String graphicPath) {

--- a/src/test/groovy/de/triplet/gradle/play/TaskHelperTest.groovy
+++ b/src/test/groovy/de/triplet/gradle/play/TaskHelperTest.groovy
@@ -2,11 +2,14 @@ package de.triplet.gradle.play
 
 import org.junit.Test
 
+import java.nio.charset.Charset
+
 import static org.junit.Assert.assertEquals
 
 class TaskHelperTest {
 
     private static final File TESTFILE = new File("src/test/fixtures/android_app/src/main/play/en-US/whatsnew")
+    private static final byte[] BYTES_NEW_LINES = [97, 13, 10, 98, 13, 10, 99, 13, 10]
 
     @Test
     public void testFilesAreCorrectlyTrimmed() {
@@ -30,5 +33,12 @@ class TaskHelperTest {
     @Test(expected = LimitExceededException.class)
     public void testIncorrectTextLength() {
         TaskHelper.readAndTrimFile(TESTFILE, 1, true)
+    }
+
+    @Test
+    public void testGetCharacterCount() {
+        def message = new String(BYTES_NEW_LINES, Charset.forName("UTF-8"))
+        assertEquals(9, message.length())
+        assertEquals(6, TaskHelper.normalizeAndTrimText(null, message, 6, true).length())
     }
 }


### PR DESCRIPTION
Special characters like umlauts are counted as more than one character while Google counts them as only one. Use BreakIterator for better counting.