### PR TITLE
Add ability to specify play data directory

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
@@ -34,6 +34,7 @@ class PlayPublisherPlugin implements Plugin<Project> {
             }
             def productFlavorName = productFlavorNames.join('')
             def flavor = StringUtils.uncapitalize(productFlavorName)
+            def metadataRoot = extension.metadataRoot
 
             def variationName = "${productFlavorName}${buildTypeName}"
 
@@ -53,7 +54,13 @@ class PlayPublisherPlugin implements Plugin<Project> {
             def bootstrapTask = project.tasks.create(bootstrapTaskName, BootstrapTask)
             bootstrapTask.extension = extension
             bootstrapTask.variant = variant
-            if (StringUtils.isNotEmpty(flavor)) {
+            if(metadataRoot) {
+                if(StringUtils.isNotEmpty(flavor)) {
+                    bootstrapTask.outputFolder = new File(metadataRoot.absolutePath, "${flavor}")
+                } else {
+                    bootstrapTask.outputFolder = new File(metadataRoot.absolutePath, "main")
+                }
+            } else if (StringUtils.isNotEmpty(flavor)) {
                 bootstrapTask.outputFolder = new File(project.projectDir, "src/${flavor}/play")
             } else {
                 bootstrapTask.outputFolder = new File(project.projectDir, "src/main/play")
@@ -64,6 +71,12 @@ class PlayPublisherPlugin implements Plugin<Project> {
             // Create and configure task to collect the play store resources.
             def playResourcesTask = project.tasks.create(playResourcesTaskName, GeneratePlayResourcesTask)
 
+            if(metadataRoot) {
+                playResourcesTask.inputs.file(new File(metadataRoot.absolutePath, "main"))
+                if(StringUtils.isNotEmpty(flavor)) {
+                    playResourcesTask.inputs.file(new File(metadataRoot.absolutePath, "${flavor}"))
+                }
+            }
             playResourcesTask.inputs.file(new File(project.projectDir, "src/main/play"))
             if (StringUtils.isNotEmpty(flavor)) {
                 playResourcesTask.inputs.file(new File(project.projectDir, "src/${flavor}/play"))

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPluginExtension.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPluginExtension.groovy
@@ -8,6 +8,8 @@ class PlayPublisherPluginExtension {
 
     File jsonFile
 
+    File metadataRoot
+
     boolean uploadImages = false
 
     boolean errorOnSizeLimit = true


### PR DESCRIPTION
This pull request adds the ability to specify the directory the play store data is stored.  This is done by assigning a directory path to `metadataRoot` in the `play` block.

For example:

```
play {
   ...
   metadataRoot = file("../play_metadata")
}
```

In our case, we have multiple configurations that are generated at build time (not flavors).  This will allow us to maintain a directory for each configuration which is chosen at build time using a gradle system property (e.g. `./gradlew publishRelease -Dconfig_id=<config_id>`).  In our case we'd set metadataRoot to something like `file("../custom_build_configs/${config_id}/play_metadata")`.