### PR TITLE
Fix regex for Filipino locale for publishing

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishTask.groovy
@@ -9,7 +9,8 @@ import org.gradle.api.DefaultTask
 class PlayPublishTask extends DefaultTask {
 
     // region '419' is a special case in the play store that represents latin america
-    def matcher = ~"^[a-z]{2}(-([A-Z]{2}|419))?\\z"
+    // 'fil' is a special case in the play store that represents Filipino
+    def matcher = ~"^(fil|[a-z]{2}(-([A-Z]{2}|419))?)\\z"
 
     PlayPublisherPluginExtension extension
 

--- a/src/test/groovy/de/triplet/gradle/play/PlayPublishTaskTest.groovy
+++ b/src/test/groovy/de/triplet/gradle/play/PlayPublishTaskTest.groovy
@@ -103,7 +103,13 @@ public class PlayPublishTaskTest {
         m = pattern.matcher("es-419")
         assertTrue(m.find())
 
+        m = pattern.matcher("fil")
+        assertTrue(m.find())
+
         m = pattern.matcher("de_DE")
+        assertFalse(m.find())
+
+        m = pattern.matcher("fil-PH")
         assertFalse(m.find())
     }
 


### PR DESCRIPTION
- Noticed that when I run a `publishListing`, it was not updating the `fil` locale with screenshots.
- Fixed the matcher regex to include the `fil` locale.
- I am not an expert in regex, but this seems to work.
- Added a couple of tests to verify
