### PR TITLE
Add Untrack APK task

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The plugin creates the following tasks for you:
 * `publishApkRelease` - Uploads the APK and the summary of recent changes.
 * `publishListingRelease` - Uploads the descriptions and images for the Play Store listing.
 * `publishRelease` - Uploads everything.
+* `untrackApkRelease` - Untrack APK from Play Store
 * `bootstrapReleasePlayResources` - Fetches all existing data from the Play Store to bootstrap the required files and folders.
 
 Make sure to set a valid `signingConfig` for the release build type. Otherwise, there won't be a publishable APK and the above tasks won't be available.
@@ -177,6 +178,24 @@ play {
 It is also possible to provide a separate summary of recent changes for each track. Just drop in a special `whatsnew-alpha` text file alongside your main `whatsnew` file and that one will be used if you publish to the alpha track.
 
 When defining the track as (staged) `rollout` you can also define a ```userFraction``` which is the portion of users who should get the staged rollout version of the APK.
+
+### Specify APK to untrack
+
+By default Google Play Developer API is not allowing us to automatically disable APK in another
+track even though it is allowed through Play Web Console. If you want to publish to another higher
+track and automatically disable from another track, it can be specified via the ```untrack``` and
+```untrackFormat``` properties.
+
+```groovy
+play {
+    // ...
+    track = 'beta'
+    untrack = 'alpha' // we untrack 'alpha' while upload to 'beta'
+    untrackFormat = '^3[0-9]{2}\$' // regex format for customisation of the versions to untrack
+}
+```
+
+It is also possible to untrack all versions by setting the ```untrackFormat``` to `*`.
 
 ### Upload Images
 

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
@@ -42,6 +42,7 @@ class PlayPublisherPlugin implements Plugin<Project> {
             def publishApkTaskName = "publishApk${variationName}"
             def publishListingTaskName = "publishListing${variationName}"
             def publishTaskName = "publish${variationName}"
+            def untrackApkTaskName = "untrackApk${variationName}"
 
             def outputData = variant.outputs.first()
             def zipAlignTask = outputData.zipAlign
@@ -106,6 +107,14 @@ class PlayPublisherPlugin implements Plugin<Project> {
                 publishTask.dependsOn publishListingTask
                 publishApkTask.dependsOn playResourcesTask
                 publishApkTask.dependsOn assembleTask
+
+                // Handle untrack
+                def untrackTask = project.tasks.create(untrackApkTaskName, PlayUntrackTask)
+                untrackTask.description = "Untrack the APK for ${variationName} channel"
+                untrackTask.extension = extension
+                untrackTask.group = PLAY_STORE_GROUP
+                untrackTask.variant = variant
+                publishApkTask.dependsOn untrackTask
             } else {
                 log.warn("Could not find ZipAlign task. Did you specify a signingConfig for the variation ${variationName}?")
             }

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPluginExtension.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPluginExtension.groovy
@@ -12,7 +12,11 @@ class PlayPublisherPluginExtension {
 
     boolean errorOnSizeLimit = true
 
+    String untrackFormat = ""
+
     private String track = 'alpha'
+
+    private String untrack = 'alpha'
 
     void setTrack(String track) {
         if (!(track in ['alpha', 'beta', 'rollout', 'production'])) {
@@ -24,6 +28,18 @@ class PlayPublisherPluginExtension {
 
     def getTrack() {
         return track
+    }
+
+    void setUntrack(String untrack) {
+        if (!(untrack in ['alpha', 'beta', 'rollout'])) {
+            throw new IllegalArgumentException("Track has to be one of 'alpha', 'beta' or 'rollout'.")
+        }
+
+        this.untrack = untrack
+    }
+
+    def getUntrack() {
+        return untrack
     }
 
     Double userFraction = 0.1

--- a/src/main/groovy/de/triplet/gradle/play/PlayUntrackTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayUntrackTask.groovy
@@ -1,0 +1,40 @@
+package de.triplet.gradle.play
+
+import com.google.api.services.androidpublisher.model.Track
+import org.gradle.api.tasks.TaskAction
+
+class PlayUntrackTask extends PlayPublishTask {
+
+    String channel = 'alpha'
+
+    boolean untrackNotNeeded() {
+      !extension.untrackFormat?.trim()
+    }
+
+    List<Integer> getVersionsToKeep(List<Integer> playStoreVersions) {
+      def pattern = extension.untrackFormat
+      if ("*".equals(pattern)) {
+        return new ArrayList<Integer>()
+      }
+      List<Integer> newVersions = playStoreVersions.findAll {
+        !(String.valueOf(it) ==~ /$pattern/)
+      }
+      return newVersions;
+    }
+
+    @TaskAction
+    untrack() {
+        if (untrackNotNeeded()) {
+            return
+        }
+
+        super.publish()
+        channel = extension.untrack
+        Track trackInfo = edits.tracks().get(variant.applicationId, editId, channel).execute();
+        List<Integer> newVersions = getVersionsToKeep(trackInfo.getVersionCodes());
+        trackInfo.setVersionCodes(newVersions);
+
+        edits.tracks().update(variant.applicationId, editId, channel, trackInfo).execute()
+        edits.commit(variant.applicationId, editId).execute()
+    }
+}

--- a/src/test/groovy/de/triplet/gradle/play/PlayPublisherPluginTest.groovy
+++ b/src/test/groovy/de/triplet/gradle/play/PlayPublisherPluginTest.groovy
@@ -118,6 +118,34 @@ class PlayPublisherPluginTest {
     }
 
     @Test
+    public void testUntrack() {
+        Project project = TestHelper.evaluatableProject()
+        project.play {
+          untrack 'rollout'
+        }
+        project.evaluate()
+
+        assertEquals('rollout', project.extensions.findByName("play").untrack)
+    }
+
+    @Test
+    public void testUntrackTask() {
+        Project project = TestHelper.evaluatableProject()
+        project.evaluate()
+
+        assertNotNull(project.tasks.untrackApkRelease)
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testThrowsOnInvalidUntrack() {
+        Project project = TestHelper.evaluatableProject()
+
+        project.play {
+          untrack 'production'
+        }
+    }
+
+    @Test
     public void testNoSigningConfigGenerateTasks() {
         Project project = TestHelper.noSigningConfigProject()
 

--- a/src/test/groovy/de/triplet/gradle/play/PlayUntrackTaskTest.groovy
+++ b/src/test/groovy/de/triplet/gradle/play/PlayUntrackTaskTest.groovy
@@ -1,0 +1,162 @@
+package de.triplet.gradle.play
+import com.google.api.services.androidpublisher.AndroidPublisher
+import com.google.api.services.androidpublisher.model.AppEdit
+import com.google.api.services.androidpublisher.model.Track
+import org.gradle.api.Project
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+import static org.mockito.Matchers.any
+import static org.mockito.Matchers.anyString
+import static org.mockito.Mockito.doReturn
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.verifyZeroInteractions
+import static org.mockito.MockitoAnnotations.initMocks
+
+class PlayUntrackTaskTest {
+
+  @Mock
+  AndroidPublisher publisherMock
+
+  @Mock
+  AndroidPublisher.Edits editsMock
+
+  @Mock
+  AndroidPublisher.Edits.Insert insertMock
+
+  @Mock
+  AndroidPublisher.Edits.Tracks editTracks;
+
+  @Mock
+  AndroidPublisher.Edits.Commit editCommit;
+
+  @Mock
+  AndroidPublisher.Edits.Tracks.Update tracksUpdate;
+
+  @Mock
+  AndroidPublisher.Edits.Tracks.Get getTrack
+
+  // These are final and not mock able
+  AppEdit appEdit = new AppEdit()
+  Track track = new Track();
+
+  ArrayList<Integer> versions = [3,301]
+
+  @Before
+  public void setup() {
+    initMocks(this)
+    track.setVersionCodes(versions)
+
+    doReturn(editsMock).when(publisherMock).edits()
+    doReturn(insertMock).when(editsMock).insert(anyString(), any(AppEdit.class))
+    doReturn(appEdit).when(insertMock).execute()
+
+    doReturn(editTracks).when(editsMock).tracks();
+    doReturn(getTrack).when(editTracks).get(anyString(), anyString(), anyString())
+    doReturn(track).when(getTrack).execute()
+
+    doReturn(tracksUpdate).when(editTracks).update(anyString(), anyString(), anyString(), any(Track.class));
+    doReturn(track).when(tracksUpdate).execute()
+    doReturn(editCommit).when(editsMock).commit(anyString(), anyString());
+  }
+
+  @Test
+  public void testUntrackNeeded() {
+    Project project = TestHelper.evaluatableProject()
+    project.play {
+      untrackFormat "a"
+    }
+    project.evaluate()
+    assertFalse(project.tasks.untrackApkRelease.untrackNotNeeded())
+  }
+
+  @Test
+  public void testUntrackDefault_notNeeded() {
+    Project project = TestHelper.evaluatableProject()
+    project.evaluate()
+    assertTrue(project.tasks.untrackApkRelease.untrackNotNeeded())
+  }
+
+  @Test
+  public void testUntrackNotNeeded() {
+    Project project = TestHelper.evaluatableProject()
+    project.evaluate()
+    assertTrue(project.tasks.untrackApkRelease.untrackNotNeeded())
+  }
+
+  @Test
+  public void testGetVersionsToKeep_matchAll() {
+    Project project = TestHelper.evaluatableProject()
+    project.play {
+      untrackFormat "3.*"
+    }
+    project.evaluate()
+    assertTrue(project.tasks.untrackApkRelease.getVersionsToKeep(versions).isEmpty())
+  }
+
+  @Test
+  public void testGetVersionsToKeep_matchOne() {
+    Project project = TestHelper.evaluatableProject()
+    project.play {
+      untrackFormat "^3[0-9]{2,4}\$"
+    }
+    project.evaluate()
+    List<Integer> keptVersions = project.tasks.untrackApkRelease.getVersionsToKeep(versions)
+    assertTrue(keptVersions.contains(versions[0]))
+    assertFalse(keptVersions.contains(versions[1]))
+  }
+
+  @Test
+  public void testGetVersionsToKeep_removeAll() {
+    Project project = TestHelper.evaluatableProject()
+    project.play {
+      untrackFormat "*"
+    }
+    project.evaluate()
+    assertTrue(project.tasks.untrackApkRelease.getVersionsToKeep(versions).isEmpty())
+  }
+
+  @Test
+  public void testUntrack_notNeeded() {
+    Project project = TestHelper.evaluatableProject()
+    project.evaluate()
+    project.tasks.untrackApkRelease.service = publisherMock;
+
+    project.tasks.untrackApkRelease.untrack()
+    verifyZeroInteractions(publisherMock.edits())
+  }
+
+  @Test
+  public void testUntrack() {
+    Project project = TestHelper.evaluatableProject()
+    project.play {
+      untrackFormat "^3[0-9]{2,4}\$"
+    }
+    project.evaluate()
+    project.tasks.untrackApkRelease.service = publisherMock;
+
+    project.tasks.untrackApkRelease.untrack()
+    assertEquals(1, track.getVersionCodes().size())
+    assertEquals(versions[0], track.getVersionCodes().get(0))
+    verify(editTracks).update(anyString(), anyString(), anyString(), any(Track.class))
+    verify(editsMock).commit(anyString(), anyString())
+  }
+
+  @Test
+  public void testUntrack_channelMatch() {
+    Project project = TestHelper.evaluatableProject()
+    project.play {
+      untrack "beta"
+      untrackFormat "^3[0-9]{2,4}\$"
+    }
+    project.evaluate()
+    project.tasks.untrackApkRelease.service = publisherMock;
+
+    project.tasks.untrackApkRelease.untrack()
+    assertEquals("beta", project.tasks.untrackApkRelease.channel)
+  }
+}


### PR DESCRIPTION
This commit adds untrackApk task for the plugin to allow user to untrack
app from another Play Store channel when they are using 2 different
channels to deploy their app.

```
gradle untrackApkRelease
```

This commit adds `untrack` and `untrackFormat` properties to the
extension to allow further customisation on which version of the app to
be disabled from Play Store.

```groovy
play {
  // untrack from alpha any active versions between 300 and 399
  untrack = 'alpha'
  untrackFormat = '^3[0-9]{2}\$'
}
```