### PR TITLE
Untracking throws exception

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.2.0-beta1
+VERSION_NAME=1.2.0-beta2
 GROUP=com.github.triplet.gradle
 
 POM_DESCRIPTION=Gradle Plugin to upload release APKs to the Google Play Store

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishApkTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishApkTask.groovy
@@ -1,6 +1,7 @@
 package de.triplet.gradle.play
 
 import com.android.build.gradle.api.ApkVariantOutput
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.FileContent
 import com.google.api.services.androidpublisher.model.Apk
 import com.google.api.services.androidpublisher.model.ApkListing
@@ -22,8 +23,8 @@ class PlayPublishApkTask extends PlayPublishTask {
         List<Integer> versionCodes = new ArrayList<Integer>()
 
         variant.outputs
-            .findAll { variantOutput -> variantOutput instanceof ApkVariantOutput }
-            .each { variantOutput -> versionCodes.add(publishApk(new FileContent(MIME_TYPE_APK, variantOutput.outputFile)).getVersionCode())}
+                .findAll { variantOutput -> variantOutput instanceof ApkVariantOutput }
+                .each { variantOutput -> versionCodes.add(publishApk(new FileContent(MIME_TYPE_APK, variantOutput.outputFile)).getVersionCode()) }
 
         Track track = new Track().setVersionCodes(versionCodes)
         if (extension.track?.equals("rollout")) {
@@ -45,12 +46,19 @@ class PlayPublishApkTask extends PlayPublishTask {
         if (extension.untrackOld && !"alpha".equals(extension.track)) {
             def untrackChannels = "beta".equals(extension.track) ? ["alpha"] : ["alpha", "beta"]
             untrackChannels.each { channel ->
-                Track track = edits.tracks().get(variant.applicationId, editId, channel).execute()
-                track.setVersionCodes(track.getVersionCodes().findAll {
-                    it > apk.getVersionCode()
-                });
+                try {
+                    Track track = edits.tracks().get(variant.applicationId, editId, channel).execute()
+                    track.setVersionCodes(track.getVersionCodes().findAll {
+                        it > apk.getVersionCode()
+                    });
 
-                edits.tracks().update(variant.applicationId, editId, channel, track).execute()
+                    edits.tracks().update(variant.applicationId, editId, channel, track).execute()
+                } catch (GoogleJsonResponseException e) {
+                    // Just skip if there is no version in track
+                    if (e.details.getCode() != 404) {
+                        throw e;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Code should omit exception thrown when there is no active version in track.

`Execution failed for task ':App:publishApkAgentRelease'.

> com.google.api.client.googleapis.json.GoogleJsonResponseException: 404 Not Found
>   {
>     "code" : 404,
>     "errors" : [ {
>       "domain" : "androidpublisher",
>       "message" : "Track not found: no APK version codes in the specified track.",
>       "reason" : "trackEmpty"
>     } ],
>     "message" : "Track not found: no APK version codes in the specified track."
>   }
> `
