### PR TITLE
Support for universal apk when splits API is enabled.

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishApkTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishApkTask.groovy
@@ -1,5 +1,6 @@
 package de.triplet.gradle.play
 
+import com.android.build.OutputFile
 import com.android.build.gradle.api.ApkVariantOutput
 import com.google.api.client.http.FileContent
 import com.google.api.services.androidpublisher.model.Apk
@@ -22,8 +23,9 @@ class PlayPublishApkTask extends PlayPublishTask {
         List<Integer> versionCodes = new ArrayList<Integer>()
 
         variant.outputs
-            .findAll { variantOutput -> variantOutput instanceof ApkVariantOutput }
-            .each { variantOutput -> versionCodes.add(publishApk(new FileContent(MIME_TYPE_APK, variantOutput.outputFile)).getVersionCode())}
+                .findAll { variantOutput -> variantOutput instanceof ApkVariantOutput }
+                .findAll { variantOutput -> (variant.outputs.size() == 1) ? true : variantOutput.getFilter(OutputFile.ABI) != null }
+                .each { variantOutput -> versionCodes.add(publishApk(new FileContent(MIME_TYPE_APK, variantOutput.outputFile)).getVersionCode()) }
 
         Track track = new Track().setVersionCodes(versionCodes)
         if (extension.track?.equals("rollout")) {

--- a/src/test/groovy/de/triplet/gradle/play/PlayPublishTaskTest.groovy
+++ b/src/test/groovy/de/triplet/gradle/play/PlayPublishTaskTest.groovy
@@ -105,6 +105,38 @@ public class PlayPublishTaskTest {
     }
 
     @Test
+    public void testAbiSplits() {
+        Project project = TestHelper.evaluatableProject()
+        project.play {
+            track 'production'
+            untrackOld true
+        }
+
+        project.android {
+            splits {
+                abi {
+                    enable true
+                    reset()
+                    include 'armeabi-v7a', 'arm64-v8a', 'mips', 'x86', 'x86_64'
+                    universalApk true
+                }
+            }
+        }
+
+        project.evaluate()
+
+        // Attach the mock
+        project.tasks.publishApkRelease.service = publisherMock
+
+        // finally run the task we want to check
+        project.tasks.publishApkRelease.publishApks()
+
+        // verify that we init the connection with the correct application id
+        verify(editsMock).insert("com.example.publisher", null)
+        verify(apksMock, times(5)).upload(eq('com.example.publisher'), eq('424242'), any(FileContent.class))
+    }
+
+    @Test
     public void testApplicationIdWithFlavorsAndSuffix() {
         Project project = TestHelper.evaluatableProject()
 


### PR DESCRIPTION
The universal apk is skipped and not uploaded to Google Play Store.