### PR TITLE
Update google publisher library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile gradleApi()
 
     compile 'com.android.tools.build:gradle:1.5.0'
-    compile('com.google.apis:google-api-services-androidpublisher:v2-rev20-1.21.0') {
+    compile('com.google.apis:google-api-services-androidpublisher:v2-rev41-1.22.0') {
         exclude group: 'com.google.guava', module: 'guava-jdk5'
     }
     compile 'commons-lang:commons-lang:2.6'


### PR DESCRIPTION
Hi @ChristianBecker !

Today we started facing issues with the `publishRelease` task on our gradle tasks.

```
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 500 Internal Server Error
{
  "code" : 500,
  "message" : null
}
        at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:145)
        at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:113)
        at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:40)
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$1.interceptResponse(AbstractGoogleClientRequest.java:321)
        at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1056)
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:419)
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:352)
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:469)
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$execute.call(Unknown Source)
        at de.triplet.gradle.play.PlayPublishApkTask.publishApk(PlayPublishApkTask.groovy:60)
        at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:73)

```

Looking at the code i've seen that the version used for the plugin is far away from december 2015.

I've updated it to latest release: