### PR TITLE
let apk task depend on general assemble task - #189

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
@@ -98,7 +98,7 @@ class PlayPublisherPlugin implements Plugin<Project> {
                 publishTask.dependsOn publishListingTask
                 publishApkTask.dependsOn playResourcesTask
 
-                variant.outputs.each { output -> publishApkTask.dependsOn output.assemble }
+                publishApkTask.dependsOn(variant.assemble)
             } else {
                 log.warn("Signing not ready. Did you specify a signingConfig for the variation ${variant.name.capitalize()}?")
             }

--- a/src/test/groovy/de/triplet/gradle/play/DependsOn.groovy
+++ b/src/test/groovy/de/triplet/gradle/play/DependsOn.groovy
@@ -27,6 +27,10 @@ class DependsOn extends TypeSafeMatcher<Task> {
                 if (((Task) o).name == mDependsOn) {
                     return true
                 }
+            } else if (String.class.isAssignableFrom(o.class)) {
+                if (((String) o) == mDependsOn) {
+                    return true
+                }
             }
         }
 

--- a/src/test/groovy/de/triplet/gradle/play/PlayPublisherPluginTest.groovy
+++ b/src/test/groovy/de/triplet/gradle/play/PlayPublisherPluginTest.groovy
@@ -280,8 +280,10 @@ class PlayPublisherPluginTest {
 
         project.evaluate()
 
-        assertThat(project.tasks.publishApkRelease, dependsOn('assembleX86Release'))
-        assertThat(project.tasks.publishApkRelease, dependsOn('assembleArmeabi-v7aRelease'))
-        assertThat(project.tasks.publishApkRelease, dependsOn('assembleMipsRelease'))
+        assertThat(project.tasks.assembleRelease, dependsOn('assembleX86Release'))
+        assertThat(project.tasks.assembleRelease, dependsOn('assembleArmeabi-v7aRelease'))
+        assertThat(project.tasks.assembleRelease, dependsOn('assembleMipsRelease'))
+
+        assertThat(project.tasks.publishApkRelease, dependsOn('assembleRelease'))
     }
 }


### PR DESCRIPTION
We don't need to depend on all the specific assemble tasks for each output. `assemble{Variant}Release` already collects all these tasks for us.