### PR TITLE
More descriptive message when text exceeds length

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishApkTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishApkTask.groovy
@@ -80,7 +80,7 @@ class PlayPublishApkTask extends PlayPublishTask {
 
                 if (whatsNewFile.exists()) {
 
-                    def whatsNewText = TaskHelper.readAndTrimFile(whatsNewFile, MAX_CHARACTER_LENGTH_FOR_WHATS_NEW_TEXT, extension.errorOnSizeLimit)
+                    def whatsNewText = TaskHelper.readAndTrimFile(project, whatsNewFile, MAX_CHARACTER_LENGTH_FOR_WHATS_NEW_TEXT, extension.errorOnSizeLimit)
                     def locale = dir.name
 
                     def newApkListing = new ApkListing().setRecentChanges(whatsNewText)

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublishListingTask.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublishListingTask.groovy
@@ -56,9 +56,9 @@ class PlayPublishListingTask extends PlayPublishTask {
                 def fileFullDescription = new File(listingDir, FILE_NAME_FOR_FULL_DESCRIPTION)
                 def fileVideo = new File(listingDir, FILE_NAME_FOR_VIDEO)
 
-                def title = TaskHelper.readAndTrimFile(fileTitle, MAX_CHARACTER_LENGTH_FOR_TITLE, extension.errorOnSizeLimit)
-                def shortDescription = TaskHelper.readAndTrimFile(fileShortDescription, MAX_CHARACTER_LENGTH_FOR_SHORT_DESCRIPTION, extension.errorOnSizeLimit)
-                def fullDescription = TaskHelper.readAndTrimFile(fileFullDescription, MAX_CHARACTER_LENGTH_FOR_FULL_DESCRIPTION, extension.errorOnSizeLimit)
+                def title = TaskHelper.readAndTrimFile(project, fileTitle, MAX_CHARACTER_LENGTH_FOR_TITLE, extension.errorOnSizeLimit)
+                def shortDescription = TaskHelper.readAndTrimFile(project, fileShortDescription, MAX_CHARACTER_LENGTH_FOR_SHORT_DESCRIPTION, extension.errorOnSizeLimit)
+                def fullDescription = TaskHelper.readAndTrimFile(project, fileFullDescription, MAX_CHARACTER_LENGTH_FOR_FULL_DESCRIPTION, extension.errorOnSizeLimit)
                 def video = TaskHelper.readSingleLine(fileVideo)
 
                 final listing = new Listing()

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
@@ -6,7 +6,8 @@ import org.gradle.api.Project
 
 class PlayPublisherPlugin implements Plugin<Project> {
 
-    public static final PLAY_STORE_GROUP = 'Play Store'
+    static final PLAY_STORE_GROUP = 'Play Store'
+    static final RESOURCES_OUTPUT_PATH = 'build/outputs/play'
 
     @Override
     void apply(Project project) {
@@ -42,7 +43,7 @@ class PlayPublisherPlugin implements Plugin<Project> {
             def bootstrapTask = project.tasks.create(bootstrapTaskName, BootstrapTask)
             bootstrapTask.extension = extension
             bootstrapTask.variant = variant
-            def accountConfigForFlavor = variant.productFlavors.find {it.playAccountConfig}?.playAccountConfig
+            def accountConfigForFlavor = variant.productFlavors.find { it.playAccountConfig }?.playAccountConfig
             def defaultAccountConfig = project.android.defaultConfig.ext.playAccountConfig
             if (!variant.flavorName.isEmpty()) {
                 bootstrapTask.outputFolder = new File(project.projectDir, "src/${variant.flavorName}/play")
@@ -63,7 +64,7 @@ class PlayPublisherPlugin implements Plugin<Project> {
             playResourcesTask.inputs.file(new File(project.projectDir, "src/${variant.buildType.name}/play"))
             playResourcesTask.inputs.file(new File(project.projectDir, "src/${variant.name}/play"))
 
-            playResourcesTask.outputFolder = new File(project.projectDir, "build/outputs/play/${variant.name}")
+            playResourcesTask.outputFolder = new File(project.projectDir, "${RESOURCES_OUTPUT_PATH}/${variant.name}")
             playResourcesTask.description = "Collects play store resources for the ${variant.name.capitalize()} build"
             playResourcesTask.group = PLAY_STORE_GROUP
 

--- a/src/main/groovy/de/triplet/gradle/play/TaskHelper.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/TaskHelper.groovy
@@ -2,18 +2,21 @@ package de.triplet.gradle.play
 
 import com.google.api.client.http.AbstractInputStreamContent
 import com.google.api.client.http.FileContent
+import org.gradle.api.Project
 
 class TaskHelper {
 
     private static final MIME_TYPE_IMAGE = 'image/*'
 
-    static readAndTrimFile(File file, int maxCharLength, boolean errorOnSizeLimit) {
+    static readAndTrimFile(Project project, File file, int maxCharLength, boolean errorOnSizeLimit) {
         if (file.exists()) {
             def message = normalize(file.text)
 
             if (message.length() > maxCharLength) {
                 if (errorOnSizeLimit) {
-                    throw new IllegalArgumentException("File '${file.parentFile.parentFile.name} -> ${file.name}' has reached the limit of ${maxCharLength} characters")
+                    def resourcesOutput = project.file(PlayPublisherPlugin.RESOURCES_OUTPUT_PATH)
+                    def relativePath = resourcesOutput.toURI().relativize(file.toURI())
+                    throw new IllegalArgumentException("File '${relativePath}' has reached the limit of ${maxCharLength} characters")
                 }
 
                 return message.substring(0, maxCharLength)

--- a/src/test/groovy/de/triplet/gradle/play/TaskHelperTest.groovy
+++ b/src/test/groovy/de/triplet/gradle/play/TaskHelperTest.groovy
@@ -1,5 +1,7 @@
 package de.triplet.gradle.play
 
+import org.gradle.api.Project
+import org.junit.Before
 import org.junit.Test
 
 import java.nio.charset.StandardCharsets
@@ -9,30 +11,37 @@ import static org.junit.Assert.fail
 
 class TaskHelperTest {
 
-    private static final TESTFILE = new File('src/test/fixtures/android_app/src/main/play/en-US/whatsnew')
-    private static final TESTFILE_WITH_LINEBREAK = new File('src/test/fixtures/android_app/src/main/play/en-US/listing/shortdescription')
-    private static final BROKEN_SINGLE_LINE = new File('src/test/fixtures/android_app/src/main/play/defaultLanguage')
+    private static final TESTFILE = new File(TestHelper.FIXTURE_WORKING_DIR, 'src/main/play/en-US/whatsnew')
+    private static final TESTFILE_WITH_LINEBREAK = new File(TestHelper.FIXTURE_WORKING_DIR, 'src/main/play/en-US/listing/shortdescription')
+    private static final BROKEN_SINGLE_LINE = new File(TestHelper.FIXTURE_WORKING_DIR, 'src/main/play/defaultLanguage')
     private static final byte[] BYTES_NEW_LINES = [97, 13, 10, 98, 13, 10, 99, 13, 10, 97]
+
+    Project project
+
+    @Before
+    void setup() {
+        project = TestHelper.evaluatableProject()
+    }
 
     @Test
     void testFilesAreCorrectlyTrimmed() {
-        assertThat(TaskHelper.readAndTrimFile(TESTFILE, 6, false)).hasSize(6)
+        assertThat(TaskHelper.readAndTrimFile(project, TESTFILE, 6, false)).hasSize(6)
     }
 
     @Test
     void testShortFilesAreNotTrimmed() {
-        assertThat(TaskHelper.readAndTrimFile(TESTFILE, 100, false)).hasSize(12)
+        assertThat(TaskHelper.readAndTrimFile(project, TESTFILE, 100, false)).hasSize(12)
     }
 
     @Test
     void testCorrectTextLength() {
-        TaskHelper.readAndTrimFile(TESTFILE, 50, true)
+        TaskHelper.readAndTrimFile(project, TESTFILE, 50, true)
     }
 
     @Test
     void testIncorrectTextLength() {
         try {
-            TaskHelper.readAndTrimFile(TESTFILE, 1, true)
+            TaskHelper.readAndTrimFile(project, TESTFILE, 1, true)
             fail()
         } catch (IllegalArgumentException e) {
             assertThat(e).hasMessageMatching('File \'.+\' has reached the limit of 1 characters')
@@ -41,7 +50,7 @@ class TaskHelperTest {
 
     @Test
     void testTrailingLinebreakIsCutOff() {
-        TaskHelper.readAndTrimFile(TESTFILE_WITH_LINEBREAK, 28, true)
+        TaskHelper.readAndTrimFile(project, TESTFILE_WITH_LINEBREAK, 28, true)
     }
 
     @Test


### PR DESCRIPTION
Include the complete relative path of the file that exceeds its limit in the IllegalArgumentException. Fixes #172

FYI @bhurling