### PR TITLE
Allow overriding rootUrl.

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/AndroidPublisherHelper.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/AndroidPublisherHelper.groovy
@@ -93,9 +93,13 @@ class AndroidPublisherHelper {
         }
 
         // Set up and return API client.
-        return new AndroidPublisher.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential)
+        def client = new AndroidPublisher.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential)
                 .setApplicationName(APPLICATION_NAME)
-                .build()
+        if (config && config.rootUrl) {
+          client.setRootUrl(config.rootUrl)
+        }
+
+        return client.build()
     }
 
     private static void newTrustedTransport() throws GeneralSecurityException,

--- a/src/main/groovy/de/triplet/gradle/play/PlayAccountConfig.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayAccountConfig.groovy
@@ -13,6 +13,8 @@ class PlayAccountConfig {
 
     File jsonFile
 
+    String rootUrl
+
     PlayAccountConfig(@NonNull String name) {
         mName = name
     }


### PR DESCRIPTION
This is useful for specifying a proxy or for pointing to
localhost for testing.