### PR TITLE
Update the Jitpack URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ buildscript {
 
     dependencies {
     	// ...
-        classpath 'com.github.triplet.gradle:play-publisher:1.2.0'
+        classpath 'com.github.Triple-T:gradle-play-publisher:1.2.0'
     }
 }
 ```


### PR DESCRIPTION
I got a 401 Unauthorized from Jitpack and searching this repo gives me that as the new url.

https://jitpack.io/#Triple-T/gradle-play-publisher/1.2.0