### PR TITLE
Allow p12 key store password, key password and key alias to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ In case you are using product flavors you will get one of the above tasks for ev
 
 Similar to Android's `signingConfigs` you need to setup so called `playAccountConfigs` to authorize your requests.
 Drop in your service account email address and the p12 key file you generated in the API Console here.
-You can optionally specify the key store password, key password and key alias if [you have changed them from the defaults](#Change your p12 password).
+You can optionally specify the key store password, key password and key alias if [you have changed them from the defaults](#change-your-p12-password).
 If you haven't changed the p12 certificate, you don't need to specify them.
  
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ In case you are using product flavors you will get one of the above tasks for ev
 
 ## Authentication
 
-Similar to Android's `signingConfigs` you need to setup so called `playAccountConfigs` to authorize your requests. Drop in your service account email address and the p12 key file you generated in the API Console here.
+Similar to Android's `signingConfigs` you need to setup so called `playAccountConfigs` to authorize your requests.
+Drop in your service account email address and the p12 key file you generated in the API Console here.
+You can optionally specify the key store password, key password and key alias if [you have changed them from the defaults](#Change your p12 password).
+If you haven't changed the p12 certificate, you don't need to specify them.
+ 
 
 ```groovy
 android {
@@ -82,6 +86,9 @@ android {
         defaultAccountConfig {
             serviceAccountEmail = 'your-service-account-email'
             pk12File = file('key.p12')
+            storePassword = 'your-key-store-password' // default value is "notasecret"
+            keyPassword = 'your-key-password' // default value is "notasecret"
+            keyAlias = 'your-key-alias' // default value is "privatekey"
         }
     }
     
@@ -314,3 +321,21 @@ project.afterEvaluate {
 ```
 
 Note that we have to wait for the evaluation phase to complete before the `generateReleasePlayResources` task becomes visible.
+
+### Change your p12 password
+
+The p12 file downloaded from the Google Play API console uses default values for the key store password and key password.
+If your p12 file is checked into your repository for your build server, you should change the passwords. In order to do this:  
+
+```
+openssl pkcs12 -in google-play-api-key.p12 -out google-play-api-key-no-password.pem -nodes
+# When prompted with "Enter Import Password:" enter "notasecret"
+openssl pkcs12 -export -out google-play-api-key-secure.p12 -in google-play-api-key-no-password.pem -name "privatekey"
+# When prompted with "Enter Export Password:" enter your secret password
+# When prompted with "Verifying - Enter Export Password:" enter your secret password again
+
+rm google-play-api-key-no-password.pem
+```
+
+The key store password and key password in the new p12 have the same value.
+You will need to specify them in your `playAccountConfigs`.

--- a/src/main/groovy/de/triplet/gradle/play/PlayAccountConfig.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayAccountConfig.groovy
@@ -11,6 +11,12 @@ class PlayAccountConfig {
 
     File pk12File
 
+    String storePassword
+
+    String keyAlias
+
+    String keyPassword
+
     File jsonFile
 
     PlayAccountConfig(@NonNull String name) {
@@ -19,6 +25,6 @@ class PlayAccountConfig {
 
     @NonNull
     public String getName() {
-        return mName;
+        return mName
     }
 }

--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPluginExtension.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPluginExtension.groovy
@@ -6,6 +6,12 @@ class PlayPublisherPluginExtension {
 
     File pk12File
 
+    String storePassword
+
+    String keyAlias
+
+    String keyPassword
+
     File jsonFile
 
     boolean uploadImages = false


### PR DESCRIPTION
Mostly copied changes from https://github.com/Triple-T/gradle-play-publisher/pull/123, it hasn't been merged and there are conflicts preventing it from being merged.

This allows you to specify passwords for your p12 file like this:

```
playAccountConfigs {
    defaultAccountConfig {
        serviceAccountEmail = 'service-account@foo.com'
        pk12File = file('google-play-api-key.p12')
        storePassword = 'your-key-store-password'
        keyPassword = 'your-key-password'
        keyAlias = 'your-key-alias'
    }
}
```

Anything not specified will fall back to the default values that were being used before this change. Previously `GoogleCredential::setServiceAccountPrivateKeyFromP12File` was being used (as opposed to `setServiceAccountPrivateKey` now), which looks like this:

```
public Builder setServiceAccountPrivateKeyFromP12File(File p12File)
    throws GeneralSecurityException, IOException {
  serviceAccountPrivateKey = SecurityUtils.loadPrivateKeyFromKeyStore(
      SecurityUtils.getPkcs12KeyStore(), new FileInputStream(p12File), "notasecret",
      "privatekey", "notasecret");
  return this;
}
```

This is needed in order to add your p12 file to your repository to be used in builds by CI servers. If you checked the original p12 file downloaded into a repository then anyone with access to the repository can potentially perform a production Play Store release (or anything that key has permission to do) on your behalf. Whilst the examples show hardcoded values in the gradle file, they will likely need to be loaded in from the environment, for my build system, it will look something like this:

```
playAccountConfigs {
    defaultAccountConfig {
        serviceAccountEmail = 'service-account@foo.com'
        pk12File = file('google-play-api-key.p12')
        storePassword = System.getenv('GOOGLE_PLAY_KEY_STORE_PASSWORD')
        keyPassword = System.getenv('GOOGLE_PLAY_KEY_PASSWORD')
    }
}
```

I've also added documentation on how to change a p12 file to have a different password.