### PR TITLE
Create "All" tasks to upload all release variants all at once.

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPlugin.groovy
@@ -29,6 +29,19 @@ class PlayPublisherPlugin implements Plugin<Project> {
             flavor.ext.playAccountConfig = android.defaultConfig.ext.playAccountConfig
         }
 
+        def publishAllTask = project.task("publishAll") {
+            description = "Updates APK and play store listing for all initiated variants build"
+            group = PLAY_STORE_GROUP
+        }
+        def publishApkAllTask = project.task("publishApkAll") {
+            description = "Uploads the APK for all initiated variants build"
+            group = PLAY_STORE_GROUP
+        }
+        def publishListingAllTask = project.task("publishListingAll") {
+            description = "Updates the play store listing for all initiated variants build"
+            group = PLAY_STORE_GROUP
+        }
+
         android.applicationVariants.whenObjectAdded { variant ->
             if (variant.buildType.isDebuggable()) {
                 log.debug("Skipping debuggable build type ${variant.buildType.name}.")
@@ -81,6 +94,7 @@ class PlayPublisherPlugin implements Plugin<Project> {
 
             // Attach tasks to task graph.
             publishListingTask.dependsOn playResourcesTask
+            publishListingAllTask.dependsOn publishListingTask
 
             if (variant.isSigningReady()) {
                 // Create and configure publisher apk task for this variant.
@@ -99,8 +113,10 @@ class PlayPublisherPlugin implements Plugin<Project> {
                 // Attach tasks to task graph.
                 publishTask.dependsOn publishApkTask
                 publishTask.dependsOn publishListingTask
+                publishApkAllTask.dependsOn publishApkTask
                 publishApkTask.dependsOn playResourcesTask
                 publishApkTask.dependsOn variant.assemble
+                publishAllTask.dependsOn publishTask
             } else {
                 log.warn("Signing not ready. Did you specify a signingConfig for the variation ${variant.name.capitalize()}?")
             }


### PR DESCRIPTION
As a app can have a lot of different variants it can be getting quite a lot of gradle tasks to list to publish them all simulatiously.
e.g. ./gradlew publishFreeRelease publishPaidRelease publishDemoRelease publishSubscriptionRelease ...

To make this more convient on the library consumer side this commit adds the tasks "publishAll", "publishApkAll" and "publishListingAll" which does the same as "publish*Release", "publishApk*Release" and "publishListing*Release" respectively but for all variants. 