### PR TITLE
Make 'internal' track default

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/PlayPublisherPluginExtension.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/PlayPublisherPluginExtension.groovy
@@ -12,7 +12,7 @@ class PlayPublisherPluginExtension {
 
     boolean errorOnSizeLimit = true
 
-    private String track = 'alpha'
+    private String track = 'internal'
 
     boolean untrackOld = false
 


### PR DESCRIPTION
Maybe now "Internal" track should be default, instead of alpha?