### PR TITLE
Downgrade android plugin to 2.3.0 to not break other people's builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
     google()
 }
 dependencies {
-    compile 'com.android.tools.build:gradle:3.1.0'
+    compile 'com.android.tools.build:gradle:2.3.0'
     compile('com.google.apis:google-api-services-androidpublisher:v2-rev41-1.22.0') {
         exclude group: 'com.google.guava', module: 'guava-jdk5'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.2.1-beta1
+VERSION_NAME=1.2.1-beta2
 GROUP=com.github.triplet.gradle
 
 POM_DESCRIPTION=Gradle Plugin to upload release APKs to the Google Play Store

--- a/src/test/groovy/de/triplet/gradle/play/TestHelper.groovy
+++ b/src/test/groovy/de/triplet/gradle/play/TestHelper.groovy
@@ -17,6 +17,7 @@ class TestHelper {
         project.apply plugin: 'com.github.triplet.play'
         project.android {
             compileSdkVersion 27
+            buildToolsVersion '27.0.3'
 
             defaultConfig {
                 versionCode 1
@@ -41,6 +42,7 @@ class TestHelper {
         project.apply plugin: 'com.github.triplet.play'
         project.android {
             compileSdkVersion 27
+            buildToolsVersion '27.0.3'
 
             defaultConfig {
                 versionCode 1


### PR DESCRIPTION
This change ensures backwards compatibility in case people are still using a version of Gradle lower than 4.4 (See comment https://github.com/Triple-T/gradle-play-publisher/issues/259#issuecomment-390972786). You can find a list of compatible versions at https://developer.android.com/studio/releases/gradle-plugin#behavior_changes_2.

With that change we can now safely release a version 1.2.1. Bumping the android plugin version should be considered a breaking change.

cc @ChristianBecker