### PR TITLE
Update to latest androidpublisher v2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 dependencies {
     compile 'com.android.tools.build:gradle:2.3.0'
-    compile('com.google.apis:google-api-services-androidpublisher:v2-rev41-1.22.0') {
+    compile('com.google.apis:google-api-services-androidpublisher:v2-rev77-1.23.0') {
         exclude group: 'com.google.guava', module: 'guava-jdk5'
     }
     compile 'commons-io:commons-io:2.4'


### PR DESCRIPTION
Even if we don't migrate yet to the v3, we should at least use the latest V2 available.