### PR TITLE
All flavors

### DIFF
--- a/src/main/kotlin/de/triplet/gradle/play/Constants.kt
+++ b/src/main/kotlin/de/triplet/gradle/play/Constants.kt
@@ -29,7 +29,7 @@ internal enum class ListingDetails(val fileName: String, val maxLength: Int = -1
     Video("video"),
     WhatsNew("whatsnew", 500);
 
-    fun saveText(dir: File, value: String) = File(dir, fileName).writeText(value)
+    fun saveText(dir: File, value: String) = File(dir.apply { mkdirs() }, fileName).writeText(value)
 }
 
 internal val JSON_FACTORY by lazy { JacksonFactory.getDefaultInstance() }

--- a/src/main/kotlin/de/triplet/gradle/play/Extensions.kt
+++ b/src/main/kotlin/de/triplet/gradle/play/Extensions.kt
@@ -32,6 +32,7 @@ internal fun File.readAndTrim(maxLength: Int, errorOnSizeLimit: Boolean, relativ
 }
 
 internal fun String?.textOrNull() = if (isNullOrEmpty()) null else this
+internal fun String?.orDefault(default: String) = this ?: default
 
 internal fun File.firstLine() = if (exists())
     bufferedReader().lineSequence().first()

--- a/src/main/kotlin/de/triplet/gradle/play/Extensions.kt
+++ b/src/main/kotlin/de/triplet/gradle/play/Extensions.kt
@@ -43,7 +43,7 @@ internal fun File.validSubFolder(vararg path: String): File? {
     var workingFile = this
     path.forEach {
         workingFile = File(workingFile, it)
-        if (!workingFile.exists() || !workingFile.mkdirs())
+        if (!workingFile.exists() && !workingFile.mkdirs())
             return null
     }
     return workingFile

--- a/src/test/groovy/de/triplet/gradle/play/PlayPublisherPluginTest.groovy
+++ b/src/test/groovy/de/triplet/gradle/play/PlayPublisherPluginTest.groovy
@@ -285,6 +285,92 @@ class PlayPublisherPluginTest {
         assertEquals('default@exmaple.com', project.tasks.publishListingRelease.playAccountConfig.serviceAccountEmail)
     }
 
+    @Test
+    void allTasksExist_AndDependOnBaseTasks_WithNoProductFlavor() {
+        def project = TestHelper.evaluatableProject()
+
+        project.android {
+            playAccountConfigs {
+                defaultAccountConfig {
+                    serviceAccountEmail = 'default@exmaple.com'
+                    pk12File = project.file('first-secret.pk12')
+                }
+            }
+
+            defaultConfig {
+                playAccountConfig = playAccountConfigs.defaultAccountConfig
+            }
+        }
+        project.evaluate()
+
+        assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapReleasePlayResources'))
+        assertThat(project.tasks.generateAll, dependsOn('generateReleasePlayResources'))
+        assertThat(project.tasks.publishAll, dependsOn('publishRelease'))
+        assertThat(project.tasks.publishApkAll, dependsOn('publishApkRelease'))
+        assertThat(project.tasks.publishListingAll, dependsOn('publishListingRelease'))
+    }
+
+    @Test
+    void allTasksExist_AndDependOnBaseTasks_ForAllProductFlavor() {
+        def project = TestHelper.evaluatableProject()
+
+        project.android {
+            playAccountConfigs {
+                defaultAccountConfig {
+                    serviceAccountEmail = 'default@exmaple.com'
+                    pk12File = project.file('first-secret.pk12')
+                }
+            }
+
+            defaultConfig {
+                playAccountConfig = playAccountConfigs.defaultAccountConfig
+            }
+
+            flavorDimensions "mode", "variant"
+
+            productFlavors {
+                demo {
+                    dimension = "mode"
+                }
+                production {
+                    dimension = "mode"
+                }
+                free {
+                    dimension = "variant"
+                }
+                paid {
+                    dimension = "variant"
+                }
+            }
+
+        }
+        project.evaluate()
+
+        assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapDemoFreeReleasePlayResources'))
+        assertThat(project.tasks.generateAll, dependsOn('generateDemoFreeReleasePlayResources'))
+        assertThat(project.tasks.publishAll, dependsOn('publishDemoFreeRelease'))
+        assertThat(project.tasks.publishApkAll, dependsOn('publishApkDemoFreeRelease'))
+        assertThat(project.tasks.publishListingAll, dependsOn('publishListingDemoFreeRelease'))
+
+        assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapDemoPaidReleasePlayResources'))
+        assertThat(project.tasks.generateAll, dependsOn('generateDemoPaidReleasePlayResources'))
+        assertThat(project.tasks.publishAll, dependsOn('publishDemoPaidRelease'))
+        assertThat(project.tasks.publishApkAll, dependsOn('publishApkDemoPaidRelease'))
+        assertThat(project.tasks.publishListingAll, dependsOn('publishListingDemoPaidRelease'))
+
+        assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapProductionFreeReleasePlayResources'))
+        assertThat(project.tasks.generateAll, dependsOn('generateProductionFreeReleasePlayResources'))
+        assertThat(project.tasks.publishAll, dependsOn('publishProductionFreeRelease'))
+        assertThat(project.tasks.publishApkAll, dependsOn('publishApkProductionFreeRelease'))
+        assertThat(project.tasks.publishListingAll, dependsOn('publishListingProductionFreeRelease'))
+
+        assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapProductionPaidReleasePlayResources'))
+        assertThat(project.tasks.generateAll, dependsOn('generateProductionPaidReleasePlayResources'))
+        assertThat(project.tasks.publishAll, dependsOn('publishProductionPaidRelease'))
+        assertThat(project.tasks.publishApkAll, dependsOn('publishApkProductionPaidRelease'))
+        assertThat(project.tasks.publishListingAll, dependsOn('publishListingProductionPaidRelease'))
+    }
+
     @Ignore("These test is not plugin specific and failing with the latest Android Gradle plugin")
     @Test
     void testSplits() {


### PR DESCRIPTION
Adds "All" level tasks for each of the tasks currently supported. Used #249 as the basis.

#117 is covered in this

This will also lays the groundwork for any other "all tasks", such as:
- Promoting builds to different channels
- Adding/updating in-app products #181