### PR TITLE
Abstract the credential stuff into a provider class.

### DIFF
--- a/src/main/kotlin/de/triplet/gradle/play/AndroidPublisherHelper.kt
+++ b/src/main/kotlin/de/triplet/gradle/play/AndroidPublisherHelper.kt
@@ -17,6 +17,7 @@ package de.triplet.gradle.play
 
 import com.google.api.client.auth.oauth2.Credential
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import com.google.api.client.http.HttpRequestInitializer
 import com.google.api.services.androidpublisher.AndroidPublisher
 import com.google.api.services.androidpublisher.AndroidPublisherScopes
 import java.io.File
@@ -36,7 +37,12 @@ internal object AndroidPublisherHelper {
         }
 
         // Set up and return API client.
-        return AndroidPublisher.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential)
+        return AndroidPublisher.Builder(HTTP_TRANSPORT, JSON_FACTORY, HttpRequestInitializer {
+            credential.initialize(it.apply {
+                connectTimeout = 100_000
+                readTimeout = 100_000
+            })
+        })
                 .setApplicationName(APPLICATION_NAME)
                 .build()
     }

--- a/src/main/kotlin/de/triplet/gradle/play/CredentialProvider.kt
+++ b/src/main/kotlin/de/triplet/gradle/play/CredentialProvider.kt
@@ -1,0 +1,38 @@
+package de.triplet.gradle.play
+
+import com.google.api.client.auth.oauth2.Credential
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import com.google.api.services.androidpublisher.AndroidPublisherScopes
+import java.io.File
+
+abstract class CredentialProvider {
+    var serviceAccountEmail: String? = null
+
+    var pk12File: File? = null
+
+    var jsonFile: File? = null
+
+    val authorization: Credential?
+        get() {
+            return authorizeWithServiceAccount(jsonFile)
+                ?: authorizeWithServiceAccount(serviceAccountEmail, pk12File)
+        }
+
+    private fun authorizeWithServiceAccount(serviceAccountEmail: String?, pk12File: File?): Credential? {
+        // Build service account credential.
+        if (serviceAccountEmail == null || pk12File == null) return null
+        return GoogleCredential.Builder()
+                .setTransport(HTTP_TRANSPORT)
+                .setJsonFactory(JSON_FACTORY)
+                .setServiceAccountId(serviceAccountEmail)
+                .setServiceAccountScopes(listOf(AndroidPublisherScopes.ANDROIDPUBLISHER))
+                .setServiceAccountPrivateKeyFromP12File(pk12File)
+                .build()
+    }
+
+    private fun authorizeWithServiceAccount(jsonFile: File?): Credential? {
+        if (jsonFile == null) return null
+        val credential = GoogleCredential.fromStream(jsonFile?.inputStream(), HTTP_TRANSPORT, JSON_FACTORY)
+        return credential.createScoped(listOf(AndroidPublisherScopes.ANDROIDPUBLISHER))
+    }
+}

--- a/src/main/kotlin/de/triplet/gradle/play/PlayAccountConfig.kt
+++ b/src/main/kotlin/de/triplet/gradle/play/PlayAccountConfig.kt
@@ -1,11 +1,3 @@
 package de.triplet.gradle.play
 
-import java.io.File
-
-open class PlayAccountConfig(var name: String = "") {
-    var serviceAccountEmail: String? = null
-
-    var pk12File: File? = null
-
-    var jsonFile: File? = null
-}
+open class PlayAccountConfig(var name: String = "") : CredentialProvider()

--- a/src/main/kotlin/de/triplet/gradle/play/PlayPublisherPluginExtension.kt
+++ b/src/main/kotlin/de/triplet/gradle/play/PlayPublisherPluginExtension.kt
@@ -1,14 +1,6 @@
 package de.triplet.gradle.play
 
-import java.io.File
-
-open class PlayPublisherPluginExtension {
-    var serviceAccountEmail: String? = null
-
-    var pk12File: File? = null
-
-    var jsonFile: File? = null
-
+open class PlayPublisherPluginExtension : CredentialProvider() {
     var uploadImages = false
 
     var errorOnSizeLimit = true


### PR DESCRIPTION
This makes the code easier to read, and means that we can better manage the process if it were to change (ie: Deprecating the old pk12 Files in the future, hopefully!)