### PR TITLE
Simplify Kotlin dependencies by using a KotlinDependencyExtension

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.41")
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.2.0")
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,0 @@
-plugins {
-    `kotlin-dsl`
-}

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,1 +1,0 @@
-const val kotlinVersion = "1.2.41"

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -10,9 +10,9 @@ dependencies {
     implementation("com.google.apis:google-api-services-androidpublisher:v2-rev77-1.23.0") {
         exclude("com.google.guava", "guava-jdk5") // Remove when upgrading to AGP 3.1+
     }
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion")
+    implementation(kotlin("stdlib-jdk7"))
 
-    testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
+    testImplementation(kotlin("test"))
     testImplementation("junit:junit:4.12")
     testImplementation("org.mockito:mockito-core:2.18.3")
     testImplementation("org.assertj:assertj-core:3.6.2")


### PR DESCRIPTION
This way we only have to declare the Kotlin version once, so I got rid of the `buildSrc` for now.