### PR TITLE
Add Versions plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,10 @@ buildscript {
     }
 }
 
+plugins {
+    id("com.github.ben-manes.versions") version "0.17.0"
+}
+
 allprojects {
     repositories {
         google()


### PR DESCRIPTION
This [Gradle plugin](https://github.com/ben-manes/gradle-versions-plugin) creates a new task `gradle dependencyUpdates` (or short `gradle dU`) that will display outdated dependencies.

For our current setup this will look like
```
> Task :dependencyUpdates

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - org.assertj:assertj-core:3.10.0
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin:0.17.0
 - junit:junit:4.12
 - org.jetbrains.kotlin:kotlin-annotation-processing-gradle:1.2.41
 - org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.41
 - org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.41
 - org.jetbrains.kotlin:kotlin-test:1.2.41
 - org.mockito:mockito-core:2.18.3

The following dependencies have later milestone versions:
 - com.google.apis:google-api-services-androidpublisher [v2-rev77-1.23.0 -> v3-rev5-1.23.0]
 - com.android.tools.build:gradle [3.0.1 -> 3.2.0-alpha16]

Failed to determine the latest version for the following dependencies (use --info for details):
 - com.vanniktech:gradle-maven-publish-plugin

Generated report file build/dependencyUpdates/report.txt
```