### PR TITLE
V3 upgrade

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
     implementation("com.android.tools.build:gradle:3.0.1")
-    implementation("com.google.apis:google-api-services-androidpublisher:v2-rev77-1.23.0") {
+    implementation("com.google.apis:google-api-services-androidpublisher:v3-rev4-1.23.0") {
         exclude("com.google.guava", "guava-jdk5") // Remove when upgrading to AGP 3.1+
     }
     implementation(kotlin("stdlib-jdk7"))

--- a/plugin/src/main/kotlin/de/triplet/gradle/play/PlayPublisherExtension.kt
+++ b/plugin/src/main/kotlin/de/triplet/gradle/play/PlayPublisherExtension.kt
@@ -52,12 +52,4 @@ open class PlayPublisherExtension : AccountConfig by PlayAccountConfigExtension(
                 "Release Status must be one of ${ReleaseStatus.values().joinToString { "'${it.status}'" }}"
             }
         }
-
-    /**
-     * Specify any default modifiers for adjusting releases after publication. (see [ModifyTrackTask])
-     *
-     * Note: Function is required for the Gradle DSL to work
-     */
-    internal var releaseModifiers: PlayReleaseModifiers? = null
-
 }

--- a/plugin/src/main/kotlin/de/triplet/gradle/play/PlayPublisherExtension.kt
+++ b/plugin/src/main/kotlin/de/triplet/gradle/play/PlayPublisherExtension.kt
@@ -1,10 +1,11 @@
 package de.triplet.gradle.play
 
 import de.triplet.gradle.play.internal.AccountConfig
-import de.triplet.gradle.play.internal.Track
+import de.triplet.gradle.play.internal.ReleaseStatus
+import de.triplet.gradle.play.internal.TrackType
 
 open class PlayPublisherExtension : AccountConfig by PlayAccountConfigExtension() {
-    internal var _track = Track.INTERNAL
+    internal var _track = TrackType.INTERNAL
     /**
      * Specify the track in which to upload your app. May be one of internal, alpha, beta, rollout,
      * or production. Default is internal.
@@ -12,8 +13,8 @@ open class PlayPublisherExtension : AccountConfig by PlayAccountConfigExtension(
     var track
         get() = _track.publishedName
         set(value) {
-            _track = requireNotNull(Track.values().find { it.name.equals(value, true) }) {
-                "Track must be one of ${Track.values().joinToString { "'${it.publishedName}'" }}"
+            _track = requireNotNull(TrackType.values().find { it.name.equals(value, true) }) {
+                "Track must be one of ${TrackType.values().joinToString { "'${it.publishedName}'" }}"
             }
         }
     /**
@@ -38,4 +39,25 @@ open class PlayPublisherExtension : AccountConfig by PlayAccountConfigExtension(
      * simply trim it. Default throws.
      */
     var errorOnSizeLimit = true
+
+    internal var _releaseStatus = ReleaseStatus.COMPLETED
+    /**
+     * Specify the status to apply to the uploaded app release. May be one of completed, draft,
+     * halted, or inProgress. Default is completed.
+     */
+    var releaseStatus: String
+        get() = _releaseStatus.status
+        set(value) {
+            _releaseStatus = requireNotNull(ReleaseStatus.values().find { it.name.equals(value, true) }) {
+                "Release Status must be one of ${ReleaseStatus.values().joinToString { "'${it.status}'" }}"
+            }
+        }
+
+    /**
+     * Specify any default modifiers for adjusting releases after publication. (see [ModifyTrackTask])
+     *
+     * Note: Function is required for the Gradle DSL to work
+     */
+    internal var releaseModifiers: PlayReleaseModifiers? = null
+
 }

--- a/plugin/src/main/kotlin/de/triplet/gradle/play/PublishApkTask.kt
+++ b/plugin/src/main/kotlin/de/triplet/gradle/play/PublishApkTask.kt
@@ -5,14 +5,8 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.FileContent
 import com.google.api.services.androidpublisher.AndroidPublisher
 import com.google.api.services.androidpublisher.model.Apk
-import com.google.api.services.androidpublisher.model.ApkListing
-import com.google.api.services.androidpublisher.model.Track
-import de.triplet.gradle.play.internal.ListingDetail
-import de.triplet.gradle.play.internal.LocaleFileFilter
 import de.triplet.gradle.play.internal.PlayPublishTaskBase
-import de.triplet.gradle.play.internal.Track.INTERNAL
-import de.triplet.gradle.play.internal.orNull
-import de.triplet.gradle.play.internal.readProcessed
+import de.triplet.gradle.play.internal.TrackType.INTERNAL
 import de.triplet.gradle.play.internal.superiors
 import org.gradle.api.tasks.TaskAction
 import java.io.File
@@ -22,44 +16,23 @@ open class PublishApkTask : PlayPublishTaskBase() {
 
     @TaskAction
     fun publishApks() = write { editId: String ->
+        //TODO: If we take in a folder here as an option, we can fix #233, #227
         val publishedApks = publishApks(editId)
-        updateTracks(editId, publishedApks)
+        updateTracks(
+                editId,
+                inputFolder,
+                extension.releaseStatus,
+                publishedApks.map { it.versionCode.toLong() },
+                extension.track,
+                extension.userFraction)
     }
 
     private fun AndroidPublisher.Edits.publishApks(editId: String) = variant.outputs
-            .filter { it is ApkVariantOutput }
-            .map { publishApk(editId, FileContent(MIME_TYPE_APK, it.outputFile)) }
-
-    private fun AndroidPublisher.Edits.updateTracks(editId: String, publishedApks: List<Apk>) {
-        tracks()
-                .update(variant.applicationId, editId, extension.track, Track()
-                        .setVersionCodes(publishedApks.map { it.versionCode })
-                        .setUserFraction(extension.userFraction))
-                .execute()
-    }
+                .filter { it is ApkVariantOutput }
+                .map { publishApk(editId, FileContent(MIME_TYPE_APK, it.outputFile)) }
 
     private fun AndroidPublisher.Edits.publishApk(editId: String, apkFile: FileContent): Apk {
         val apk = apks().upload(variant.applicationId, editId, apkFile).execute()
-
-        fun updateWhatsNew(locale: File) {
-            val fileName = ListingDetail.WHATS_NEW.fileName
-            val file = run {
-                var file = File(locale, "$fileName-${extension.track}").orNull()
-                if (file == null) file = File(locale, fileName).orNull()
-                file
-            } ?: return
-
-            val listing = ApkListing().apply {
-                recentChanges = File(file, fileName).readProcessed(
-                        ListingDetail.WHATS_NEW.maxLength,
-                        extension.errorOnSizeLimit
-                )
-            }
-
-            apklistings()
-                    .update(variant.applicationId, editId, apk.versionCode, locale.name, listing)
-                    .execute()
-        }
 
         if (extension.untrackOld && extension._track != INTERNAL) {
             extension._track.superiors.map { it.publishedName }.forEach { channel ->
@@ -69,9 +42,10 @@ open class PublishApkTask : PlayPublishTaskBase() {
                             editId,
                             channel
                     ).execute().apply {
-                        versionCodes = versionCodes.filter { it > apk.versionCode }
+                        releases.forEach {
+                            it.versionCodes = it.versionCodes.filter { it > apk.versionCode.toLong() }
+                        }
                     }
-
                     tracks().update(variant.applicationId, editId, channel, track).execute()
                 } catch (e: GoogleJsonResponseException) {
                     // Just skip if there is no version in track
@@ -86,11 +60,6 @@ open class PublishApkTask : PlayPublishTaskBase() {
             deobfuscationfiles()
                     .upload(variant.applicationId, editId, apk.versionCode, "proguard", content)
                     .execute()
-        }
-
-        if (inputFolder.exists()) {
-            // Matches valid locales e.g. en-US for Play Store
-            inputFolder.listFiles(LocaleFileFilter).forEach { updateWhatsNew(it) }
         }
 
         return apk

--- a/plugin/src/main/kotlin/de/triplet/gradle/play/internal/PlayPublishTaskBase.kt
+++ b/plugin/src/main/kotlin/de/triplet/gradle/play/internal/PlayPublishTaskBase.kt
@@ -6,8 +6,12 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.androidpublisher.AndroidPublisher
 import com.google.api.services.androidpublisher.AndroidPublisherScopes
+import com.google.api.services.androidpublisher.model.LocalizedText
+import com.google.api.services.androidpublisher.model.Track
+import com.google.api.services.androidpublisher.model.TrackRelease
 import de.triplet.gradle.play.PlayPublisherExtension
 import org.gradle.api.DefaultTask
+import java.io.File
 
 abstract class PlayPublishTaskBase : DefaultTask() {
     lateinit var extension: PlayPublisherExtension
@@ -71,5 +75,47 @@ abstract class PlayPublishTaskBase : DefaultTask() {
     ) = read {
         block(it)
         commit(variant.applicationId, it).execute()
+    }
+
+    internal fun AndroidPublisher.Edits.updateTracks(
+            editId: String,
+            inputFolder: File,
+            releaseStatus: String,
+            versions: List<Long>,
+            trackType: String,
+            userPercent: Double) {
+        val track = tracks()
+                .list(variant.applicationId, editId)
+                .execute().tracks?.firstOrNull { it.track == trackType }
+                ?: Track()
+
+        var releaseText: List<LocalizedText>? = null
+        if (inputFolder.exists()) {
+            releaseText = inputFolder.listFiles(LocaleFileFilter).map { locale ->
+                val fileName = ListingDetail.WHATS_NEW.fileName
+                val file = run {
+                    var file = File(locale, "$fileName-${extension.track}").orNull()
+                    if (file == null) file = File(locale, fileName).orNull()
+                    file
+                } ?: return@map null
+                val recentChanges = File(file, fileName).readProcessed(
+                        ListingDetail.WHATS_NEW.maxLength,
+                        extension.errorOnSizeLimit
+                )
+                LocalizedText().setLanguage(locale.name).setText(recentChanges)
+            }.filterNotNull()
+        }
+        val trackRelease = TrackRelease().apply {
+            releaseNotes = releaseText
+            status = releaseStatus
+            userFraction = if (status == ReleaseStatus.INPROGRESS.status) userPercent else 0.0
+            versionCodes = versions
+        }
+
+        track.releases = listOf(trackRelease)
+
+        tracks()
+                .update(variant.applicationId, editId, trackType, track)
+                .execute()
     }
 }

--- a/plugin/src/main/kotlin/de/triplet/gradle/play/internal/Tracks.kt
+++ b/plugin/src/main/kotlin/de/triplet/gradle/play/internal/Tracks.kt
@@ -1,12 +1,26 @@
 package de.triplet.gradle.play.internal
 
-internal val Track.superiors get() = Track.values().takeWhile { it != this && it != Track.ROLLOUT }
+internal val TrackType.superiors get() = TrackType.values().takeWhile { it != this && it != TrackType.ROLLOUT }
 
-internal enum class Track(val publishedName: String) {
+internal enum class TrackType(val publishedName: String) {
     // Note: changing the order breaks API compatibility
     INTERNAL("internal"),
     ALPHA("alpha"),
     BETA("beta"),
     ROLLOUT("rollout"),
-    PRODUCTION("production")
+    PRODUCTION("production");
+
+    companion object {
+        fun fromString(value: String): TrackType {
+            return values().first { it.publishedName.equals(value, true) }
+        }
+    }
 }
+
+internal enum class ReleaseStatus(val status: String) {
+    COMPLETED("completed"),
+    DRAFT("draft"),
+    HALTED("halted"),
+    INPROGRESS("inProgress");
+}
+


### PR DESCRIPTION
Upgrades to v3 of the Publisher API, with support for drafts.  #283 #252

Also moves the `updateTrack` logic in preparation of the Modify tasks. #284 