### PR TITLE
Remove generateAll task

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -72,7 +72,8 @@ class PlayPublisherPlugin : Plugin<Project> {
 
             val playResourcesTask = project.newTask<GeneratePlayResourcesTask>(
                     "generate${variantName}PlayResources",
-                    "Collects Play Store resources for $variantName."
+                    "Collects Play Store resources for $variantName.",
+                    null
             ) {
                 inputs.file("src/main/$PLAY_PATH")
                 if (variant.flavorName.isNotEmpty()) {

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -30,10 +30,6 @@ class PlayPublisherPlugin : Plugin<Project> {
                 "bootstrapAll",
                 "Downloads the Play Store listing metadata for all variants."
         )
-        val playResourcesAllTask = project.newTask<Task>(
-                "generateAll",
-                "Collects Play Store resources for all variants."
-        )
         val publishAllTask = project.newTask<Task>(
                 "publishAll",
                 "Uploads APK or App Bundle and all Play Store metadata for every variant."
@@ -86,8 +82,6 @@ class PlayPublisherPlugin : Plugin<Project> {
                 inputs.file("src/${variant.name}/$PLAY_PATH")
 
                 outputFolder = File(project.buildDir, "$RESOURCES_OUTPUT_PATH/${variant.name}")
-
-                playResourcesAllTask.dependsOn(this)
             }
             val publishListingTask = project.newTask<PublishListingTask>(
                     "publishListing$variantName",

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
@@ -15,7 +15,7 @@ internal inline fun <reified T> ExtensionContainer.get() = findByType(T::class.j
 internal inline fun <reified T : Task> Project.newTask(
         name: String,
         description: String,
-        group: String = PLUGIN_GROUP,
+        group: String? = PLUGIN_GROUP,
         block: T.() -> Unit = {}
 ): T = tasks.create(name, T::class.java).apply {
     this.description = description

--- a/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublisherPluginTest.groovy
+++ b/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublisherPluginTest.groovy
@@ -462,7 +462,6 @@ class PlayPublisherPluginTest {
         project.evaluate()
 
         assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapReleasePlayResources'))
-        assertThat(project.tasks.generateAll, dependsOn('generateReleasePlayResources'))
         assertThat(project.tasks.publishAll, dependsOn('publishRelease'))
         assertThat(project.tasks.publishApkAll, dependsOn('publishApkRelease'))
         assertThat(project.tasks.publishListingAll, dependsOn('publishListingRelease'))
@@ -505,25 +504,21 @@ class PlayPublisherPluginTest {
         project.evaluate()
 
         assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapDemoFreeReleasePlayResources'))
-        assertThat(project.tasks.generateAll, dependsOn('generateDemoFreeReleasePlayResources'))
         assertThat(project.tasks.publishAll, dependsOn('publishDemoFreeRelease'))
         assertThat(project.tasks.publishApkAll, dependsOn('publishApkDemoFreeRelease'))
         assertThat(project.tasks.publishListingAll, dependsOn('publishListingDemoFreeRelease'))
 
         assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapDemoPaidReleasePlayResources'))
-        assertThat(project.tasks.generateAll, dependsOn('generateDemoPaidReleasePlayResources'))
         assertThat(project.tasks.publishAll, dependsOn('publishDemoPaidRelease'))
         assertThat(project.tasks.publishApkAll, dependsOn('publishApkDemoPaidRelease'))
         assertThat(project.tasks.publishListingAll, dependsOn('publishListingDemoPaidRelease'))
 
         assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapProductionFreeReleasePlayResources'))
-        assertThat(project.tasks.generateAll, dependsOn('generateProductionFreeReleasePlayResources'))
         assertThat(project.tasks.publishAll, dependsOn('publishProductionFreeRelease'))
         assertThat(project.tasks.publishApkAll, dependsOn('publishApkProductionFreeRelease'))
         assertThat(project.tasks.publishListingAll, dependsOn('publishListingProductionFreeRelease'))
 
         assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapProductionPaidReleasePlayResources'))
-        assertThat(project.tasks.generateAll, dependsOn('generateProductionPaidReleasePlayResources'))
         assertThat(project.tasks.publishAll, dependsOn('publishProductionPaidRelease'))
         assertThat(project.tasks.publishApkAll, dependsOn('publishApkProductionPaidRelease'))
         assertThat(project.tasks.publishListingAll, dependsOn('publishListingProductionPaidRelease'))


### PR DESCRIPTION
This one is up for debate: the generate tasks are internal and don't really serve a purpose outside of prepping for the publish listing task so I don't see why we should add another user facing task. What do you guys think?