### PR TITLE
Auto-deploy snapshots from Travis CI to Sonatype

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Deploy a jar, source jar, and javadoc jar to Sonatype's snapshot repo.
+#
+# Adapted from https://coderwall.com/p/9b_lfq and
+# http://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/ and
+# https://github.com/JakeWharton/butterknife/blob/master/.buildscript/deploy_snapshot.sh
+
+SLUG="Triple-T/gradle-play-publisher"
+JDK="oraclejdk8"
+BRANCH="master"
+
+set -e
+
+if [ "$TRAVIS_REPO_SLUG" != "$SLUG" ]; then
+  echo "Skipping snapshot deployment: wrong repository. Expected '$SLUG' but was '$TRAVIS_REPO_SLUG'."
+elif [ "$TRAVIS_JDK_VERSION" != "$JDK" ]; then
+  echo "Skipping snapshot deployment: wrong JDK. Expected '$JDK' but was '$TRAVIS_JDK_VERSION'."
+elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo "Skipping snapshot deployment: was pull request."
+elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
+  echo "Skipping snapshot deployment: wrong branch. Expected '$BRANCH' but was '$TRAVIS_BRANCH'."
+else
+  echo "Deploying snapshot..."
+  ./gradlew uploadArchives
+  echo "Snapshot deployed!"
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,38 @@
 language: android
+
 jdk: oraclejdk8
-before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-cache:
-  directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
-  timeout: 300 # 5 minutes
+
 before_install:
   - mkdir "$ANDROID_HOME/licenses" || true
   - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
   - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd\n504667f4c0de7af1a06de9f4b1727b84351f2910" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
+
 android:
   components:
     # https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943
     - tools
     - tools
+
 before_script: chmod +x gradlew
+
 script: ./gradlew build
+
+after_success: .buildscript/deploy_snapshot.sh
+
+env:
+  global:
+    - secure: "HG2SDI/pIrNwLNk+KmWBExjQo/I+dTlPywJU9r7Xwm7yR+oK3B5MFjH7kZ3AHwbOibo7cvSnJfs7RhlYo/Ta3Z/AiIEskVzMRy9XLQHBRD9t4nkaa1GY98dWgjKnngaRvgcpvWgS3M2A69d8OnPNX858Ge2WchwXvd0bWTS5a9U="
+    - secure: "O1Smf6Jli0+465ym+C2zV3ZLseA7/LRdgMCojNUU6bKLvM7SY5sGv47m0tlCdFKNvOUijFXYWYmcSpNWFZ7avQROFMKjWXGcE7aKTZsbh42+tzzqW8IYKWMzlH7d3ZbzALTvYVNLn6pdcRJOlHiC0ApnAMvfci8MG7d50xB3yQM="
+
+notifications:
+  email: false
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+  timeout: 300 # 5 minutes

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the Google Play Store from a continuous integration server or anywhere you have 
 
 1. Upload the first version of your APK or App Bundle using the
    [Google Play Console](https://play.google.com/apps/publish)
-1. [Create a Google Play Service Account](#google-play-service-account)
+1. [Create a Google Play Service Account](#service-account)
 1. [Sign your release builds](https://developer.android.com/studio/publish/app-signing#gradle-sign)
    with a valid `signingConfig`
 1. [Add and apply the plugin](#installation)
@@ -90,19 +90,19 @@ apply plugin: 'com.github.triplet.play'
 
 #### Snapshot builds
 
-If you're prepared to cut yourself on the bleeding edge of this plugin, snapshot builds are
-available through JitPack:
+If you're prepared to cut yourself on the bleeding edge of this plugin, snapshot builds are available in [Sonatype's
+`snapshots` repository](https://oss.sonatype.org/content/repositories/snapshots/):
 
 ```groovy
 buildscript {
     repositories {
         // ...
-        maven { url 'https://jitpack.io' }
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     }
 
     dependencies {
         // ...
-        implementation 'com.github.Triple-T:gradle-play-publisher:commitId' // E.g. 75bed587f8
+        classpath 'com.github.triplet.gradle:play-publisher:2.0.0-SNAPSHOT'
     }
 }
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,18 +3,19 @@ org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.caching=true
 
-VERSION_NAME=2.0.0-SNAPSHOT
 GROUP=com.github.triplet.gradle
+VERSION_NAME=2.0.0-SNAPSHOT
 
-POM_DESCRIPTION=Gradle Plugin to upload release APKs to the Google Play Store
+POM_DESCRIPTION=Gradle Plugin to upload APKs and App Bundles to the Google Play Store
+
 POM_URL=https://github.com/Triple-T/gradle-play-publisher
 POM_SCM_URL=https://github.com/Triple-T/gradle-play-publisher
 POM_SCM_CONNECTION=scm:git@github.com:Triple-T/gradle-play-publisher.git
 POM_SCM_DEV_CONNECTION=scm:git@github.com:Triple-T/gradle-play-publisher.git
+
 POM_LICENCE_NAME=The MIT License (MIT)
 POM_LICENCE_URL=http://opensource.org/licenses/MIT
 POM_LICENCE_DIST=repo
 
-POM_NAME=Google Play Publisher Gradle Plugin
-POM_ARTIFACT_ID=play-publisher
-POM_PACKAGING=jar
+POM_DEVELOPER_ID=Triple-T
+POM_DEVELOPER_NAME=Triple-T-Dev

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=Google Play Publisher Gradle Plugin
+POM_ARTIFACT_ID=play-publisher
+POM_PACKAGING=jar


### PR DESCRIPTION
See the [latest SNAPSHOT releases](https://oss.sonatype.org/content/repositories/snapshots/com/github/triplet/gradle/play-publisher/2.0.0-SNAPSHOT/). The last one (`play-publisher-2.0.0-20180605.085714-2.jar`) was created from a preview version of this commit.