### PR TITLE
Feature: retrieve latest play version code, increment and add it

### DIFF
--- a/src/main/kotlin/de/triplet/gradle/play/AutoIncrementVersionCodeTask.kt
+++ b/src/main/kotlin/de/triplet/gradle/play/AutoIncrementVersionCodeTask.kt
@@ -1,0 +1,28 @@
+package de.triplet.gradle.play
+
+import com.android.build.gradle.api.ApkVariantOutput
+import org.gradle.api.tasks.TaskAction
+
+open class AutoIncrementVersionCodeTask : PlayPublishTask() {
+
+    @TaskAction
+    fun autoIncrement() {
+        publish()
+
+        val versionCode = requestLatestPlayVersionCode()
+        overrideVersionCode(versionCode + 1)
+    }
+
+    private fun overrideVersionCode(versionCode: Int) {
+        variant.outputs.filterIsInstance<ApkVariantOutput>().map { it.versionCodeOverride = versionCode }
+    }
+
+    private fun requestLatestPlayVersionCode(): Int {
+        logger.info("Request latest VersionCode for application '${variant.applicationId}'")
+        val apksListResponse = edits.apks().list(variant.applicationId, editId).execute()
+        val latestApk = apksListResponse.apks.last()
+        val latestVersionCode = latestApk.versionCode
+        logger.info("Found this play version code for application '${variant.applicationId}': $latestVersionCode")
+        return latestVersionCode ?: 0
+    }
+}

--- a/src/main/kotlin/de/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/src/main/kotlin/de/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -60,6 +60,7 @@ class PlayPublisherPlugin : Plugin<Project> {
 
             val bootstrapTaskName = "bootstrap${capName}PlayResources"
             val playResourcesTaskName = "generate${capName}PlayResources"
+            val autoIncrementVersionCodeTaskName = "autoIncrement${capName}VersionCode"
             val publishApkTaskName = "publishApk$capName"
             val publishListingTaskName = "publishListing$capName"
             val publishTaskName = "publish$capName"
@@ -89,6 +90,18 @@ class PlayPublisherPlugin : Plugin<Project> {
                 group = PLAY_STORE_GROUP
             }
             playResourcesAllTask.dependsOn(playResourcesTask)
+
+            // Create and configure task to auto increment the play store version code
+            val autoIncrementVersionCodeTask = project.tasks.create(
+                    autoIncrementVersionCodeTaskName, AutoIncrementVersionCodeTask::class.java).apply {
+                this.extension = extension
+                this.playAccountConfig = playAccountConfig
+                this.variant = variant
+                setOnlyIf({ extension.autoIncrementVersion })
+                description = "Retrieves the latest play store version code, increments and then adds it to the $capName build."
+                group = PLAY_STORE_GROUP
+            }
+            variant.preBuild.dependsOn(autoIncrementVersionCodeTask)
 
             // Create and configure publisher meta task for this variant
             val publishListingTask = project.tasks.create(publishListingTaskName, PlayPublishListingTask::class.java).apply {

--- a/src/main/kotlin/de/triplet/gradle/play/PlayPublisherPluginExtension.kt
+++ b/src/main/kotlin/de/triplet/gradle/play/PlayPublisherPluginExtension.kt
@@ -24,4 +24,6 @@ open class PlayPublisherPluginExtension {
     var untrackOld = false
 
     var userFraction = 0.1
+
+    var autoIncrementVersion = false
 }


### PR DESCRIPTION
Implemented PR #248 in Kotlin.

This PR still intents to publish Apps to the PlayStore without manually updating the VersionCode. 
It does this by requesting the latest released VersionCode via PlayPublisher, increments this number by one and sets it as the new VersionCode before building a release APK.