### PR TITLE
Update AndroidPublisher to v3-rev12-1.23.0

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
     implementation("com.android.tools.build:gradle:3.0.1")
-    implementation("com.google.apis:google-api-services-androidpublisher:v3-rev6-1.23.0") {
+    implementation("com.google.apis:google-api-services-androidpublisher:v3-rev12-1.23.0") {
         exclude("com.google.guava", "guava-jdk5") // Remove when upgrading to AGP 3.1+
     }
     implementation(kotlin("stdlib-jdk7"))


### PR DESCRIPTION
Unfortunately, there are no release notes available. But the build is green, so we're good to go!