### PR TITLE
Start adding v2.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,32 @@
 **2.0.0 - to be released**
 
 * Convert plugin to Kotlin
-* Bump Android Publisher plugin v2 version
+* Bump Android Publisher plugin version to v3
+* Allow overriding configuration via command line options - #326
+* Fully support multi-dimensional flavors - #130, #311
+* Fill missing metadata with data for the default language - #107, #323
+* Support gradle cache and incremental builds - #304, #308
+* Support different resolution strategies in case of version conflicts - #301
+
+***Breaking changes***
+
+*Updated listings structure*
+
+As a precondition for supporting multi-dimensional flavors the structure of listings metadata 
+has changed:
+
+For example, english listing files have moved 
+
+```
+../play/en-US/listing/shortdescription --> ../play/listings/en-US/shortdescription
+```
+
+*Removed configuration properties*
+* Removed `uploadImages`: As this plugin now makes use of gradle's caching system and
+incremental builds (#308), it is no longer required to define this property. 
+Images will only be uploaded if they have changed.
+* Removed `untrackOld`: With the introduction of conflict resolution strategies (#301) 
+this property has become obsolete.
 
 **1.2.2 - 2018-05-24**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Fill missing metadata with data from the default language - #107, #323
 * Support gradle cache and incremental builds - #304, #308
 * Support different resolution strategies in case of version conflicts - #301
-* Add group tasks to publish all variants at once - #
+* Add group tasks to publish all variants at once - #117, #273
 * Provide publishing tasks even when `signingConfig` is missing - #244, #298
 * Improve error messages and logging - #238, #268
 * Add status indicators and upload progress - #298

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 * Bump Android Publisher plugin version to v3
 * Allow overriding configuration via command line options - #326
 * Fully support multi-dimensional flavors - #130, #311
-* Fill missing metadata with data for the default language - #107, #323
+* Fill missing metadata with data from the default language - #107, #323
 * Support gradle cache and incremental builds - #304, #308
 * Support different resolution strategies in case of version conflicts - #301
+* Add group tasks to publish all variants at once - #
+* Provide publishing tasks even when `signingConfig` is missing - #244, #298
+* Improve error messages and logging - #238, #268
+* Add status indicators and upload progress - #298
 
 ***Breaking changes***
 
@@ -22,6 +26,7 @@ For example, english listing files have moved
 ```
 
 *Removed configuration properties*
+
 * Removed `uploadImages`: As this plugin now makes use of gradle's caching system and
 incremental builds (#308), it is no longer required to define this property. 
 Images will only be uploaded if they have changed.


### PR DESCRIPTION
Can go into master as the changelog states that 2.0.0 has not been released yet