### PR TITLE
Remove `All` suffix from tasks

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -34,19 +34,19 @@ class PlayPublisherPlugin : Plugin<Project> {
                 project.extensions.create(PLAY_PATH, PlayPublisherExtension::class.java)
 
         val bootstrapAllTask = project.newTask<Task>(
-                "bootstrapAll",
+                "bootstrap",
                 "Downloads the Play Store listing metadata for all variants."
         )
         val publishAllTask = project.newTask<Task>(
-                "publishAll",
+                "publish",
                 "Uploads APK or App Bundle and all Play Store metadata for every variant."
         )
         val publishApkAllTask = project.newTask<Task>(
-                "publishApkAll",
+                "publishApk",
                 "Uploads APK for every variant."
         )
         val publishListingAllTask = project.newTask<Task>(
-                "publishListingAll",
+                "publishListing",
                 "Uploads all Play Store metadata for every variant."
         )
 

--- a/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublisherPluginTest.groovy
+++ b/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublisherPluginTest.groovy
@@ -424,10 +424,10 @@ class PlayPublisherPluginTest {
         }
         project.evaluate()
 
-        assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapReleasePlayResources'))
-        assertThat(project.tasks.publishAll, dependsOn('publishRelease'))
-        assertThat(project.tasks.publishApkAll, dependsOn('publishApkRelease'))
-        assertThat(project.tasks.publishListingAll, dependsOn('publishListingRelease'))
+        assertThat(project.tasks.bootstrap, dependsOn('bootstrapReleasePlayResources'))
+        assertThat(project.tasks.publish, dependsOn('publishRelease'))
+        assertThat(project.tasks.publishApk, dependsOn('publishApkRelease'))
+        assertThat(project.tasks.publishListing, dependsOn('publishListingRelease'))
     }
 
     @Test
@@ -466,24 +466,24 @@ class PlayPublisherPluginTest {
         }
         project.evaluate()
 
-        assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapDemoFreeReleasePlayResources'))
-        assertThat(project.tasks.publishAll, dependsOn('publishDemoFreeRelease'))
-        assertThat(project.tasks.publishApkAll, dependsOn('publishApkDemoFreeRelease'))
-        assertThat(project.tasks.publishListingAll, dependsOn('publishListingDemoFreeRelease'))
+        assertThat(project.tasks.bootstrap, dependsOn('bootstrapDemoFreeReleasePlayResources'))
+        assertThat(project.tasks.publish, dependsOn('publishDemoFreeRelease'))
+        assertThat(project.tasks.publishApk, dependsOn('publishApkDemoFreeRelease'))
+        assertThat(project.tasks.publishListing, dependsOn('publishListingDemoFreeRelease'))
 
-        assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapDemoPaidReleasePlayResources'))
-        assertThat(project.tasks.publishAll, dependsOn('publishDemoPaidRelease'))
-        assertThat(project.tasks.publishApkAll, dependsOn('publishApkDemoPaidRelease'))
-        assertThat(project.tasks.publishListingAll, dependsOn('publishListingDemoPaidRelease'))
+        assertThat(project.tasks.bootstrap, dependsOn('bootstrapDemoPaidReleasePlayResources'))
+        assertThat(project.tasks.publish, dependsOn('publishDemoPaidRelease'))
+        assertThat(project.tasks.publishApk, dependsOn('publishApkDemoPaidRelease'))
+        assertThat(project.tasks.publishListing, dependsOn('publishListingDemoPaidRelease'))
 
-        assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapProductionFreeReleasePlayResources'))
-        assertThat(project.tasks.publishAll, dependsOn('publishProductionFreeRelease'))
-        assertThat(project.tasks.publishApkAll, dependsOn('publishApkProductionFreeRelease'))
-        assertThat(project.tasks.publishListingAll, dependsOn('publishListingProductionFreeRelease'))
+        assertThat(project.tasks.bootstrap, dependsOn('bootstrapProductionFreeReleasePlayResources'))
+        assertThat(project.tasks.publish, dependsOn('publishProductionFreeRelease'))
+        assertThat(project.tasks.publishApk, dependsOn('publishApkProductionFreeRelease'))
+        assertThat(project.tasks.publishListing, dependsOn('publishListingProductionFreeRelease'))
 
-        assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapProductionPaidReleasePlayResources'))
-        assertThat(project.tasks.publishAll, dependsOn('publishProductionPaidRelease'))
-        assertThat(project.tasks.publishApkAll, dependsOn('publishApkProductionPaidRelease'))
-        assertThat(project.tasks.publishListingAll, dependsOn('publishListingProductionPaidRelease'))
+        assertThat(project.tasks.bootstrap, dependsOn('bootstrapProductionPaidReleasePlayResources'))
+        assertThat(project.tasks.publish, dependsOn('publishProductionPaidRelease'))
+        assertThat(project.tasks.publishApk, dependsOn('publishApkProductionPaidRelease'))
+        assertThat(project.tasks.publishListing, dependsOn('publishListingProductionPaidRelease'))
     }
 }


### PR DESCRIPTION
This follows the convention established by the AGP. For example, there `assembleDebug` and `assembleRelease`. The combination of the two is simply `assemble`, not `assembleAll`.

PS: this isn't a breaking change because these tasks were introduced in v2.0.