### PR TITLE
Follow variant task naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Images will only be uploaded if they have changed.
 * Removed `untrackOld`: With the introduction of conflict resolution strategies (#301) 
 this property has become obsolete.
 
+#### Renamed tasks to follow AGP conventions
+
+For example, `publishApkRelease` -> `publishReleaseApk`. Note: the old tasks are still available for
+now, but will be removed in a future release.
+
 **1.2.2 - 2018-05-24**
 
 * More descriptive error message when texts exceed allowed length - #172

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -96,7 +96,7 @@ class PlayPublisherPlugin : Plugin<Project> {
                 resDir = File(project.buildDir, "${variant.playPath}/res")
             }
             val publishListingTask = project.newTask<PublishListing>(
-                    "publishListing$variantName",
+                    "publish${variantName}Listing",
                     "Uploads all Play Store metadata for $variantName."
             ) {
                 init()
@@ -107,7 +107,7 @@ class PlayPublisherPlugin : Plugin<Project> {
             }
 
             val processPackageMetadata = project.newTask<ProcessPackageMetadata>(
-                    "processPackageMetadata$variantName",
+                    "process${variantName}Metadata",
                     "Processes packaging metadata for $variantName.",
                     null
             ) {
@@ -117,7 +117,7 @@ class PlayPublisherPlugin : Plugin<Project> {
             }
 
             val publishApkTask = project.newTask<PublishApk>(
-                    "publishApk$variantName",
+                    "publish${variantName}Apk",
                     "Uploads APK for $variantName."
             ) {
                 init()

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -104,6 +104,13 @@ class PlayPublisherPlugin : Plugin<Project> {
 
                 dependsOn(playResourcesTask)
                 publishListingAllTask.dependsOn(this)
+
+                // Remove in v3.0
+                val new = this
+                project.newTask<Task>("publishListing$variantName", "", null) {
+                    dependsOn(new)
+                    doFirst { logger.warn("$name is deprecated, use ${new.name} instead") }
+                }
             }
 
             val processPackageMetadata = project.newTask<ProcessPackageMetadata>(
@@ -127,6 +134,13 @@ class PlayPublisherPlugin : Plugin<Project> {
                 dependsOn(playResourcesTask)
                 dependsOn(variant.assemble)
                 publishApkAllTask.dependsOn(this)
+
+                // Remove in v3.0
+                val new = this
+                project.newTask<Task>("publishApk$variantName", "", null) {
+                    dependsOn(new)
+                    doFirst { logger.warn("$name is deprecated, use ${new.name} instead") }
+                }
             }
 
             project.newTask<Task>(

--- a/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublishTaskTest.groovy
+++ b/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublishTaskTest.groovy
@@ -2,24 +2,20 @@ package com.github.triplet.gradle.play
 
 import com.github.triplet.gradle.play.internal.PlayPublishTaskBase
 import com.github.triplet.gradle.play.internal.TrackType
-import com.github.triplet.gradle.play.tasks.PublishApk
 import com.google.api.client.http.FileContent
 import com.google.api.services.androidpublisher.AndroidPublisher
 import com.google.api.services.androidpublisher.model.Apk
 import com.google.api.services.androidpublisher.model.AppEdit
 import com.google.api.services.androidpublisher.model.Track
-import com.google.api.services.androidpublisher.model.TrackRelease
 import com.google.api.services.androidpublisher.model.TracksListResponse
 import kotlin.LazyKt
 import org.gradle.api.Task
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatcher
 import org.mockito.Mock
 
 import static org.mockito.ArgumentMatchers.anyString
-import static org.mockito.ArgumentMatchers.argThat
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.ArgumentMatchers.nullable
 import static org.mockito.Mockito.doReturn
@@ -145,10 +141,10 @@ class PlayPublishTaskTest {
         project.evaluate()
 
         // Attach the mock
-        setMockPublisher(project.tasks.publishApkPaidRelease)
+        setMockPublisher(project.tasks.publishPaidReleaseApk)
 
         // finally run the task we want to check
-        project.tasks.publishApkPaidRelease.publishApks(inputsMock)
+        project.tasks.publishPaidReleaseApk.publishApks(inputsMock)
 
         // verify that we init the connection with the correct application id
         verify(editsMock).insert('com.example.publisher.paid.release', null)
@@ -161,43 +157,11 @@ class PlayPublishTaskTest {
         field.set(task, LazyKt.lazy { publisherMock })
     }
 
-    private void publishApk(Task task) {
-        def progressLogger = findBaseTask(task.class, PlayPublishTaskBase.class)
-                .getDeclaredField("progressLogger")
-        progressLogger.setAccessible(true)
-        progressLogger.get(task).start("Desc", null)
-
-        def publishApk = findBaseTask(task.class, PublishApk.class).getDeclaredMethod(
-                "publishApk", AndroidPublisher.Edits.class, String.class, FileContent.class)
-        publishApk.setAccessible(true)
-        publishApk.invoke(task, editsMock, "424242", new FileContent(null, new File("foo")))
-    }
-
     private Class<? super Task> findBaseTask(Class<? super Task> start, Class<? super Task> end) {
         if (start == end) {
             return end as Class<? super Task>
         } else {
             return findBaseTask(start.superclass, end)
         }
-    }
-
-    static Track emptyTrack() {
-        return argThat(new ArgumentMatcher<Track>() {
-            @Override
-            boolean matches(Track track) {
-                return track.getReleases().sum {
-                    (it as TrackRelease).getVersionCodes().size()
-                } == 0
-            }
-        })
-    }
-
-    static Track trackThatContains(final Long code) {
-        return argThat(new ArgumentMatcher<Track>() {
-            @Override
-            boolean matches(Track track) {
-                return track.getReleases().find { it.getVersionCodes().contains(code) } != null
-            }
-        })
     }
 }

--- a/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublisherPluginTest.groovy
+++ b/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublisherPluginTest.groovy
@@ -28,7 +28,7 @@ class PlayPublisherPluginTest {
         project.evaluate()
 
         assertNotNull(project.tasks.publishRelease)
-        assertEquals(project.tasks.publishApkRelease.variant, project.android.applicationVariants[1])
+        assertEquals(project.tasks.publishReleaseApk.variant, project.android.applicationVariants[1])
     }
 
     @Test
@@ -53,8 +53,8 @@ class PlayPublisherPluginTest {
         assertNotNull(project.tasks.publishPaidRelease)
         assertNotNull(project.tasks.publishFreeRelease)
 
-        assertEquals(project.tasks.publishApkFreeRelease.variant, project.android.applicationVariants[3])
-        assertEquals(project.tasks.publishApkPaidRelease.variant, project.android.applicationVariants[1])
+        assertEquals(project.tasks.publishFreeReleaseApk.variant, project.android.applicationVariants[3])
+        assertEquals(project.tasks.publishPaidReleaseApk.variant, project.android.applicationVariants[1])
     }
 
     @Test
@@ -252,8 +252,8 @@ class PlayPublisherPluginTest {
 
         project.evaluate()
 
-        assertNotNull(project.tasks.publishListingFreeRelease)
-        assertNotNull(project.tasks.publishListingPaidRelease)
+        assertNotNull(project.tasks.publishFreeReleaseListing)
+        assertNotNull(project.tasks.publishPaidReleaseListing)
     }
 
     @Test
@@ -330,13 +330,13 @@ class PlayPublisherPluginTest {
         assertEquals('first-mail@exmaple.com', project.tasks.bootstrapFreeReleasePlayResources.accountConfig.serviceAccountEmail)
         assertEquals('another-mail@exmaple.com', project.tasks.bootstrapPaidReleasePlayResources.accountConfig.serviceAccountEmail)
 
-        assertEquals('default@exmaple.com', project.tasks.publishApkDefaultFlavorRelease.accountConfig.serviceAccountEmail)
-        assertEquals('first-mail@exmaple.com', project.tasks.publishApkFreeRelease.accountConfig.serviceAccountEmail)
-        assertEquals('another-mail@exmaple.com', project.tasks.publishApkPaidRelease.accountConfig.serviceAccountEmail)
+        assertEquals('default@exmaple.com', project.tasks.publishDefaultFlavorReleaseApk.accountConfig.serviceAccountEmail)
+        assertEquals('first-mail@exmaple.com', project.tasks.publishFreeReleaseApk.accountConfig.serviceAccountEmail)
+        assertEquals('another-mail@exmaple.com', project.tasks.publishPaidReleaseApk.accountConfig.serviceAccountEmail)
 
-        assertEquals('default@exmaple.com', project.tasks.publishListingDefaultFlavorRelease.accountConfig.serviceAccountEmail)
-        assertEquals('first-mail@exmaple.com', project.tasks.publishListingFreeRelease.accountConfig.serviceAccountEmail)
-        assertEquals('another-mail@exmaple.com', project.tasks.publishListingPaidRelease.accountConfig.serviceAccountEmail)
+        assertEquals('default@exmaple.com', project.tasks.publishDefaultFlavorReleaseListing.accountConfig.serviceAccountEmail)
+        assertEquals('first-mail@exmaple.com', project.tasks.publishFreeReleaseListing.accountConfig.serviceAccountEmail)
+        assertEquals('another-mail@exmaple.com', project.tasks.publishPaidReleaseListing.accountConfig.serviceAccountEmail)
     }
 
     @Test
@@ -402,8 +402,8 @@ class PlayPublisherPluginTest {
         project.evaluate()
 
         assertEquals('default@exmaple.com', project.tasks.bootstrapReleasePlayResources.accountConfig.serviceAccountEmail)
-        assertEquals('default@exmaple.com', project.tasks.publishApkRelease.accountConfig.serviceAccountEmail)
-        assertEquals('default@exmaple.com', project.tasks.publishListingRelease.accountConfig.serviceAccountEmail)
+        assertEquals('default@exmaple.com', project.tasks.publishReleaseApk.accountConfig.serviceAccountEmail)
+        assertEquals('default@exmaple.com', project.tasks.publishReleaseListing.accountConfig.serviceAccountEmail)
     }
 
     @Test
@@ -426,8 +426,8 @@ class PlayPublisherPluginTest {
 
         assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapReleasePlayResources'))
         assertThat(project.tasks.publishAll, dependsOn('publishRelease'))
-        assertThat(project.tasks.publishApkAll, dependsOn('publishApkRelease'))
-        assertThat(project.tasks.publishListingAll, dependsOn('publishListingRelease'))
+        assertThat(project.tasks.publishApkAll, dependsOn('publishReleaseApk'))
+        assertThat(project.tasks.publishListingAll, dependsOn('publishReleaseListing'))
     }
 
     @Test
@@ -468,22 +468,22 @@ class PlayPublisherPluginTest {
 
         assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapDemoFreeReleasePlayResources'))
         assertThat(project.tasks.publishAll, dependsOn('publishDemoFreeRelease'))
-        assertThat(project.tasks.publishApkAll, dependsOn('publishApkDemoFreeRelease'))
-        assertThat(project.tasks.publishListingAll, dependsOn('publishListingDemoFreeRelease'))
+        assertThat(project.tasks.publishApkAll, dependsOn('publishDemoFreeReleaseApk'))
+        assertThat(project.tasks.publishListingAll, dependsOn('publishDemoFreeReleaseListing'))
 
         assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapDemoPaidReleasePlayResources'))
         assertThat(project.tasks.publishAll, dependsOn('publishDemoPaidRelease'))
-        assertThat(project.tasks.publishApkAll, dependsOn('publishApkDemoPaidRelease'))
-        assertThat(project.tasks.publishListingAll, dependsOn('publishListingDemoPaidRelease'))
+        assertThat(project.tasks.publishApkAll, dependsOn('publishDemoPaidReleaseApk'))
+        assertThat(project.tasks.publishListingAll, dependsOn('publishDemoPaidReleaseListing'))
 
         assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapProductionFreeReleasePlayResources'))
         assertThat(project.tasks.publishAll, dependsOn('publishProductionFreeRelease'))
-        assertThat(project.tasks.publishApkAll, dependsOn('publishApkProductionFreeRelease'))
-        assertThat(project.tasks.publishListingAll, dependsOn('publishListingProductionFreeRelease'))
+        assertThat(project.tasks.publishApkAll, dependsOn('publishProductionFreeReleaseApk'))
+        assertThat(project.tasks.publishListingAll, dependsOn('publishProductionFreeReleaseListing'))
 
         assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapProductionPaidReleasePlayResources'))
         assertThat(project.tasks.publishAll, dependsOn('publishProductionPaidRelease'))
-        assertThat(project.tasks.publishApkAll, dependsOn('publishApkProductionPaidRelease'))
-        assertThat(project.tasks.publishListingAll, dependsOn('publishListingProductionPaidRelease'))
+        assertThat(project.tasks.publishApkAll, dependsOn('publishProductionPaidReleaseApk'))
+        assertThat(project.tasks.publishListingAll, dependsOn('publishProductionPaidReleaseListing'))
     }
 }


### PR DESCRIPTION
Example Android tasks:
- transformClassesWithDexBuilder**For**Release
- assemble**Release**
- generate**Release**Sources

The AGP never puts the variant at the end of the task name unless it's prefixed with `for` or it's the last word. Migrate our tasks to this: `publishApkRelease` -> `publishReleaseApk`. It sounds a lot nicer IMO.