### PR TITLE
Simplify Service Account credentials API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,10 @@ Images will only be uploaded if they have changed.
 * Removed `untrackOld`: With the introduction of conflict resolution strategies (#301) 
 this property has become obsolete.
 
-#### Renamed tasks to follow AGP conventions
+#### Simplified Service Account credentials API
 
-For example, `publishApkRelease` -> `publishReleaseApk`. Note: the old tasks are still available for
-now, but will be removed in a future release.
+The `jsonFile` and `pk12File` properties have been replaced with a unified
+`serviceAccountCredentials` property.
 
 **1.2.2 - 2018-05-24**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Images will only be uploaded if they have changed.
 * Removed `untrackOld`: With the introduction of conflict resolution strategies (#301) 
 this property has become obsolete.
 
+#### Renamed tasks to follow AGP conventions
+
+For example, `publishApkRelease` -> `publishReleaseApk`. Note: the old tasks are still available for
+now, but will be removed in a future release.
+
 **1.2.2 - 2018-05-24**
 
 * More descriptive error message when texts exceed allowed length - #172

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayAccountConfigExtension.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayAccountConfigExtension.kt
@@ -12,9 +12,7 @@ data class PlayAccountConfigExtension @JvmOverloads constructor(
         @get:Internal internal val name: String = "", // Needed for Gradle
 
         @get:PathSensitive(PathSensitivity.RELATIVE) @get:InputFile @get:Optional
-        override var jsonFile: File? = null,
-        @get:PathSensitive(PathSensitivity.RELATIVE) @get:InputFile @get:Optional
-        override var pk12File: File? = null,
+        override var serviceAccountCredentials: File? = null,
         @get:PathSensitive(PathSensitivity.RELATIVE) @get:InputFile @get:Optional
         override var serviceAccountEmail: String? = null
 ) : AccountConfig

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -65,8 +65,14 @@ class PlayPublisherPlugin : Plugin<Project> {
                         "Signing not ready. Be sure to specify a signingConfig for $variantName")
             }
             accountConfig.run {
-                check(jsonFile != null || pk12File != null && serviceAccountEmail != null) {
-                    "No credentials provided"
+                if (_serviceAccountCredentials.extension.equals("json", true)) {
+                    check(serviceAccountEmail == null) {
+                        "Json credentials cannot specify a Service Account email"
+                    }
+                } else {
+                    check(serviceAccountEmail != null) {
+                        "PKCS12 credentials must also specify a Service Account email"
+                    }
                 }
             }
 

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/AccountConfig.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/AccountConfig.kt
@@ -1,24 +1,25 @@
 package com.github.triplet.gradle.play.internal
 
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import java.io.File
 
 interface AccountConfig {
-    /** Service Account authentication file. JSON will be prioitized over pk12. */
+    @get:Internal
+    val _serviceAccountCredentials
+        get() = checkNotNull(serviceAccountCredentials) { "No credentials provided" }
+    /**
+     * Service Account authentication file. Json is preferred, but PKCS12 is also supported. For
+     * PKCS12 to work, the [serviceAccountEmail] must be specified.
+     */
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFile
-    @get:Optional
-    var jsonFile: File?
+    var serviceAccountCredentials: File?
 
-    /** Service Account authentication file. JSON will be prioitized over pk12. */
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    @get:InputFile
-    @get:Optional
-    var pk12File: File?
-    /** Service Account email. Only needed when using pk12 auth. */
+    /** Service Account email. Only needed if PKCS12 credentials are used. */
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFile
     @get:Optional

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/PlayPublishTaskBase.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/PlayPublishTaskBase.kt
@@ -24,24 +24,21 @@ abstract class PlayPublishTaskBase : DefaultTask(), ExtensionOptions {
 
     private val publisher by lazy {
         val credential = accountConfig.run {
-            val jsonFile = jsonFile
-            val pk12File = pk12File
+            val creds = _serviceAccountCredentials
             val serviceAccountEmail = serviceAccountEmail
             val factory = JacksonFactory.getDefaultInstance()
 
-            if (jsonFile != null) {
-                GoogleCredential.fromStream(jsonFile.inputStream(), transport, factory)
+            if (serviceAccountEmail == null) {
+                GoogleCredential.fromStream(creds.inputStream(), transport, factory)
                         .createScoped(listOf(AndroidPublisherScopes.ANDROIDPUBLISHER))
-            } else if (pk12File != null && serviceAccountEmail != null) {
+            } else {
                 GoogleCredential.Builder()
                         .setTransport(transport)
                         .setJsonFactory(factory)
                         .setServiceAccountId(serviceAccountEmail)
-                        .setServiceAccountPrivateKeyFromP12File(pk12File)
+                        .setServiceAccountPrivateKeyFromP12File(creds)
                         .setServiceAccountScopes(listOf(AndroidPublisherScopes.ANDROIDPUBLISHER))
                         .build()
-            } else {
-                throw IllegalArgumentException("No credentials provided.")
             }
         }
 

--- a/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublisherPluginTest.groovy
+++ b/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublisherPluginTest.groovy
@@ -261,12 +261,12 @@ class PlayPublisherPluginTest {
         def project = TestHelper.evaluatableProject()
 
         project.play {
-            jsonFile new File('key.json')
+            serviceAccountCredentials new File('key.json')
         }
 
         project.evaluate()
 
-        assertEquals('key.json', project.extensions.play.jsonFile.name)
+        assertEquals('key.json', project.extensions.play.serviceAccountCredentials.name)
     }
 
     @Test
@@ -275,13 +275,13 @@ class PlayPublisherPluginTest {
 
         project.play {
             serviceAccountEmail = 'service-account@test.com'
-            pk12File = new File('key.p12')
+            serviceAccountCredentials = new File('key.p12')
         }
 
         project.evaluate()
 
         assertEquals('service-account@test.com', project.extensions.play.serviceAccountEmail)
-        assertEquals(new File('key.p12'), project.extensions.play.pk12File)
+        assertEquals(new File('key.p12'), project.extensions.play.serviceAccountCredentials)
     }
 
     @Test
@@ -292,15 +292,15 @@ class PlayPublisherPluginTest {
             playAccountConfigs {
                 defaultAccountConfig {
                     serviceAccountEmail = 'default@exmaple.com'
-                    pk12File = project.file('first-secret.pk12')
+                    serviceAccountCredentials = project.file('first-secret.pk12')
                 }
                 free {
                     serviceAccountEmail = 'first-mail@exmaple.com'
-                    pk12File = project.file('secret.pk12')
+                    serviceAccountCredentials = project.file('secret.pk12')
                 }
                 paid {
                     serviceAccountEmail = 'another-mail@exmaple.com'
-                    pk12File = project.file('another-secret.pk12')
+                    serviceAccountCredentials = project.file('another-secret.pk12')
                 }
             }
 
@@ -350,11 +350,11 @@ class PlayPublisherPluginTest {
             playAccountConfigs {
                 free {
                     serviceAccountEmail = 'free@exmaple.com'
-                    pk12File = project.file('secret.pk12')
+                    serviceAccountCredentials = project.file('secret.pk12')
                 }
                 paid {
                     serviceAccountEmail = 'paid@exmaple.com'
-                    pk12File = project.file('another-secret.pk12')
+                    serviceAccountCredentials = project.file('another-secret.pk12')
                 }
             }
 
@@ -391,7 +391,7 @@ class PlayPublisherPluginTest {
             playAccountConfigs {
                 defaultAccountConfig {
                     serviceAccountEmail = 'default@exmaple.com'
-                    pk12File = project.file('first-secret.pk12')
+                    serviceAccountCredentials = project.file('first-secret.pk12')
                 }
             }
 
@@ -409,19 +409,6 @@ class PlayPublisherPluginTest {
     @Test
     void allTasksExist_AndDependOnBaseTasks_WithNoProductFlavor() {
         def project = TestHelper.evaluatableProject()
-
-        project.android {
-            playAccountConfigs {
-                defaultAccountConfig {
-                    serviceAccountEmail = 'default@exmaple.com'
-                    pk12File = project.file('first-secret.pk12')
-                }
-            }
-
-            defaultConfig {
-                playAccountConfig = playAccountConfigs.defaultAccountConfig
-            }
-        }
         project.evaluate()
 
         assertThat(project.tasks.bootstrapAll, dependsOn('bootstrapReleasePlayResources'))
@@ -435,17 +422,6 @@ class PlayPublisherPluginTest {
         def project = TestHelper.evaluatableProject()
 
         project.android {
-            playAccountConfigs {
-                defaultAccountConfig {
-                    serviceAccountEmail = 'default@exmaple.com'
-                    pk12File = project.file('first-secret.pk12')
-                }
-            }
-
-            defaultConfig {
-                playAccountConfig = playAccountConfigs.defaultAccountConfig
-            }
-
             flavorDimensions "mode", "variant"
 
             productFlavors {

--- a/plugin/src/test/groovy/com/github/triplet/gradle/play/TestHelper.groovy
+++ b/plugin/src/test/groovy/com/github/triplet/gradle/play/TestHelper.groovy
@@ -39,7 +39,7 @@ class TestHelper {
             }
         }
         project.play {
-            jsonFile = new File("Fake")
+            serviceAccountCredentials = new File("fake.json")
         }
 
         return project


### PR DESCRIPTION
Motivation: `pk12File` and `jsonFile` are meaningless names and make for a pretty unpleasant API. The new API unifies those files under the banner of `serviceAccountCredentials` and intelligently selects the right credential while providing descriptive errors messages if something doesn't match up.