### PR TITLE
Remove nonsensical trim feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ incremental builds (#308), it is no longer required to define this property.
 Images will only be uploaded if they have changed.
 * Removed `untrackOld`: With the introduction of conflict resolution strategies (#301) 
 this property has become obsolete.
+* `errorOnSizeLimit`: The plugin will now always error on size limit to provide deterministic
+  behavior.
 
 **1.2.2 - 2018-05-24**
 

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherExtension.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherExtension.kt
@@ -30,13 +30,6 @@ open class PlayPublisherExtension : AccountConfig by PlayAccountConfigExtension(
     @get:Input
     var userFraction = 0.1
 
-    /**
-     * Choose whether or not to throw an error should a Play Store listing detail be too large or
-     * simply trim it. Default throws.
-     */
-    @get:Input
-    var errorOnSizeLimit = true
-
     @get:Internal("Backing property for public input")
     internal var _resolutionStrategy = ResolutionStrategy.FAIL
     /**

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -95,6 +95,7 @@ class PlayPublisherPlugin : Plugin<Project> {
                 init()
                 resDir = File(project.buildDir, "${variant.playPath}/res")
             }
+
             val publishListingTask = project.newTask<PublishListing>(
                     "publishListing$variantName",
                     "Uploads all Play Store metadata for $variantName."

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/ExtensionOptions.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/ExtensionOptions.kt
@@ -34,17 +34,6 @@ internal interface ExtensionOptions {
             extension.userFraction = value.toDouble()
         }
 
-    @get:Internal
-    @set:Option(
-            option = "trim-on-size-limit",
-            description = "Trim listing details instead of failing should they be too large."
-    )
-    var trimOnSizeLimitOption: Boolean
-        get() = throw UnsupportedOperationException()
-        set(value) {
-            extension.errorOnSizeLimit = !value
-        }
-
     @get:OptionValues("resolution-strategy")
     val resolutionStrategyOptions
         get() = ResolutionStrategy.values().map { it.publishedName }

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Io.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Io.kt
@@ -12,8 +12,8 @@ internal tailrec fun File.findClosestDir(): File {
 internal fun File.climbUpTo(parentName: String): File? =
         if (name == parentName) this else parentFile?.climbUpTo(parentName)
 
-internal fun File.readProcessed(maxLength: Int, error: Boolean) =
-        readText().normalized().takeOrThrow(maxLength, error, this)
+internal fun File.readProcessed(maxLength: Int) =
+        readText().normalized().throwOnOverflow(maxLength, this)
 
 internal fun File.isChildOf(parentName: String) = climbUpTo(parentName) != null
 
@@ -28,10 +28,7 @@ internal fun String.normalized() = replace(Regex("\\r\\n"), "\n").trim()
 
 internal fun String?.nullOrFull() = if (isNullOrBlank()) null else this
 
-private fun String.takeOrThrow(n: Int, error: Boolean, file: File): String {
-    val result = take(n)
-    if (error) check(result.length == length) {
-        "File '$file' has reached the limit of $n characters."
-    }
-    return result
+private fun String.throwOnOverflow(max: Int, file: File): String {
+    check(length <= max) { "File '$file' has reached the limit of $max characters." }
+    return this
 }

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/PlayPublishPackageBase.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/PlayPublishPackageBase.kt
@@ -25,11 +25,10 @@ abstract class PlayPublishPackageBase : PlayPublishTaskBase() {
                     ?: File(locale, RELEASE_NOTES_DEFAULT_NAME).orNull()
                     ?: return@mapNotNull null
 
-            val recentChanges = file.readProcessed(
-                    RELEASE_NOTES_MAX_LENGTH,
-                    extension.errorOnSizeLimit
-            )
-            LocalizedText().setLanguage(locale.name).setText(recentChanges)
+            LocalizedText().apply {
+                language = locale.name
+                text = file.readProcessed(RELEASE_NOTES_MAX_LENGTH)
+            }
         }
         val trackRelease = TrackRelease().apply {
             releaseNotes = releaseTexts

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishListing.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishListing.kt
@@ -78,16 +78,12 @@ open class PublishListing : PlayPublishTaskBase() {
     private fun AndroidPublisher.Edits.updateAppDetails(editId: String) {
         progressLogger.progress("Uploading app details")
         val details = AppDetails().apply {
-            val errorOnSizeLimit = extension.errorOnSizeLimit
+            fun AppDetail.read() = File(resDir, fileName).orNull()?.readProcessed(maxLength)
 
-            defaultLanguage = File(resDir, AppDetail.DEFAULT_LANGUAGE.fileName).orNull()
-                    ?.readProcessed(AppDetail.DEFAULT_LANGUAGE.maxLength, errorOnSizeLimit)
-            contactEmail = File(resDir, AppDetail.CONTACT_EMAIL.fileName).orNull()
-                    ?.readProcessed(AppDetail.CONTACT_EMAIL.maxLength, errorOnSizeLimit)
-            contactPhone = File(resDir, AppDetail.CONTACT_PHONE.fileName).orNull()
-                    ?.readProcessed(AppDetail.CONTACT_PHONE.maxLength, errorOnSizeLimit)
-            contactWebsite = File(resDir, AppDetail.CONTACT_WEBSITE.fileName).orNull()
-                    ?.readProcessed(AppDetail.CONTACT_WEBSITE.maxLength, errorOnSizeLimit)
+            defaultLanguage = AppDetail.DEFAULT_LANGUAGE.read()
+            contactEmail = AppDetail.CONTACT_EMAIL.read()
+            contactPhone = AppDetail.CONTACT_PHONE.read()
+            contactWebsite = AppDetail.CONTACT_WEBSITE.read()
         }
 
         details().update(variant.applicationId, editId, details).execute()
@@ -100,18 +96,12 @@ open class PublishListing : PlayPublishTaskBase() {
     ) {
         progressLogger.progress("Uploading $locale listing")
         val listing = Listing().apply {
-            val errorOnSizeLimit = extension.errorOnSizeLimit
+            fun ListingDetail.read() = File(listingDir, fileName).orNull()?.readProcessed(maxLength)
 
-            title = File(listingDir, ListingDetail.TITLE.fileName).orNull()
-                    ?.readProcessed(ListingDetail.TITLE.maxLength, errorOnSizeLimit)
-            shortDescription = File(listingDir, ListingDetail.SHORT_DESCRIPTION.fileName)
-                    .orNull()
-                    ?.readProcessed(ListingDetail.SHORT_DESCRIPTION.maxLength, errorOnSizeLimit)
-            fullDescription = File(listingDir, ListingDetail.FULL_DESCRIPTION.fileName)
-                    .orNull()
-                    ?.readProcessed(ListingDetail.FULL_DESCRIPTION.maxLength, errorOnSizeLimit)
-            video = File(listingDir, ListingDetail.VIDEO.fileName).orNull()
-                    ?.readProcessed(ListingDetail.VIDEO.maxLength, errorOnSizeLimit)
+            title = ListingDetail.TITLE.read()
+            shortDescription = ListingDetail.SHORT_DESCRIPTION.read()
+            fullDescription = ListingDetail.FULL_DESCRIPTION.read()
+            video = ListingDetail.VIDEO.read()
         }
 
         try {

--- a/plugin/src/test/kotlin/com/github/triplet/gradle/play/ExtensionsTest.kt
+++ b/plugin/src/test/kotlin/com/github/triplet/gradle/play/ExtensionsTest.kt
@@ -20,29 +20,19 @@ class ExtensionsTest {
                 .build()
     }
 
-    @Test
-    fun `Long files are trimmed`() {
-        assertThat(project.file(TEST_FILE).readProcessed(2, false)).hasSize(2)
-    }
-
-    @Test
-    fun `Files on the edge are trimmed correctly`() {
-        assertThat(project.file(TEST_FILE).readProcessed(4, false)).hasSize(4)
-    }
-
-    @Test
-    fun `Short files aren't trimmed`() {
-        assertThat(project.file(TEST_FILE).readProcessed(100, false)).hasSize(4)
-    }
-
     @Test(expected = IllegalStateException::class)
-    fun `Throws on overflow`() {
-        project.file(TEST_FILE).readProcessed(1, true)
+    fun `Long files throw overflow`() {
+        project.file(TEST_FILE).readProcessed(1)
     }
 
     @Test
-    fun `File is trimmed`() {
-        project.file(FILE_WITH_LINEBREAK).readProcessed(28, true)
+    fun `Files on the edge don't throw`() {
+        assertThat(project.file(TEST_FILE).readProcessed(4)).hasSize(4)
+    }
+
+    @Test
+    fun `Short files don't throw`() {
+        assertThat(project.file(TEST_FILE).readProcessed(100)).hasSize(4)
     }
 
     @Test
@@ -53,7 +43,6 @@ class ExtensionsTest {
 
     private companion object {
         const val TEST_FILE = "src/main/play/release-notes/en-US/default"
-        const val FILE_WITH_LINEBREAK = "src/main/play/listings/en-US/shortdescription"
 
         val newLine = byteArrayOf(97, 13, 10, 98, 13, 10, 99, 13, 10, 97)
                 .toString(StandardCharsets.UTF_8)


### PR DESCRIPTION
I haven't touched this "feature" because I thought it was a user request (otherwise why would there by an extra config option), but it turns out this was just another case of trying to Do the Right Thing™️.

Feature origin story:
- Originally, file lengths weren't checked when uploaded
- Checks were added, but they trimmed the files by default
- #66 fixed that bug with a config flag instead of just throwing on overflow

I don't see any possible case where someone would want non-deterministic behavior so this feature should be killed, hence the PR.