### PR TITLE
Release notes fixes and other annotation improvements

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayAccountConfigExtension.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayAccountConfigExtension.kt
@@ -12,7 +12,7 @@ import java.io.File
 data class PlayAccountConfigExtension @JvmOverloads constructor(
         @get:Internal internal val name: String = "", // Needed for Gradle
 
-        @get:PathSensitive(PathSensitivity.RELATIVE) @get:InputFile
+        @get:PathSensitive(PathSensitivity.RELATIVE) @get:Optional @get:InputFile
         override var serviceAccountCredentials: File? = null,
         @get:Optional @get:Input
         override var serviceAccountEmail: String? = null

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayAccountConfigExtension.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayAccountConfigExtension.kt
@@ -1,6 +1,7 @@
 package com.github.triplet.gradle.play
 
 import com.github.triplet.gradle.play.internal.AccountConfig
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
@@ -11,8 +12,8 @@ import java.io.File
 data class PlayAccountConfigExtension @JvmOverloads constructor(
         @get:Internal internal val name: String = "", // Needed for Gradle
 
-        @get:PathSensitive(PathSensitivity.RELATIVE) @get:InputFile @get:Optional
+        @get:PathSensitive(PathSensitivity.RELATIVE) @get:InputFile
         override var serviceAccountCredentials: File? = null,
-        @get:PathSensitive(PathSensitivity.RELATIVE) @get:InputFile @get:Optional
+        @get:Optional @get:Input
         override var serviceAccountEmail: String? = null
 ) : AccountConfig

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -6,7 +6,6 @@ import com.github.triplet.gradle.play.internal.ACCOUNT_CONFIG
 import com.github.triplet.gradle.play.internal.AccountConfig
 import com.github.triplet.gradle.play.internal.PLAY_PATH
 import com.github.triplet.gradle.play.internal.PlayPublishTaskBase
-import com.github.triplet.gradle.play.internal.RELEASE_NOTES_PATH
 import com.github.triplet.gradle.play.internal.flavorNameOrDefault
 import com.github.triplet.gradle.play.internal.get
 import com.github.triplet.gradle.play.internal.newTask
@@ -135,7 +134,7 @@ class PlayPublisherPlugin : Plugin<Project> {
                     "Uploads APK for $variantName."
             ) {
                 init()
-                releaseNotesDir = File(playResourcesTask.resDir, RELEASE_NOTES_PATH)
+                resDir = playResourcesTask.resDir
 
                 dependsOn(processPackageMetadata)
                 dependsOn(playResourcesTask)

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/AccountConfig.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/AccountConfig.kt
@@ -17,6 +17,7 @@ interface AccountConfig {
      * PKCS12 to work, the [serviceAccountEmail] must be specified.
      */
     @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:Optional // Optional because it could be set in the `playAccountConfigs`
     @get:InputFile
     var serviceAccountCredentials: File?
 

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/AccountConfig.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/AccountConfig.kt
@@ -1,5 +1,6 @@
 package com.github.triplet.gradle.play.internal
 
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
@@ -20,8 +21,7 @@ interface AccountConfig {
     var serviceAccountCredentials: File?
 
     /** Service Account email. Only needed if PKCS12 credentials are used. */
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    @get:InputFile
     @get:Optional
+    @get:Input
     var serviceAccountEmail: String?
 }

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Io.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Io.kt
@@ -12,17 +12,21 @@ internal tailrec fun File.findClosestDir(): File {
 internal fun File.climbUpTo(parentName: String): File? =
         if (name == parentName) this else parentFile?.climbUpTo(parentName)
 
-internal fun File.readProcessed(maxLength: Int) =
-        readText().normalized().throwOnOverflow(maxLength, this)
-
 internal fun File.isChildOf(parentName: String) = climbUpTo(parentName) != null
 
 internal fun File.isDirectChildOf(parentName: String) = parentFile?.name == parentName
 
+internal fun File.safeMkdirs() = apply {
+    check(exists() || mkdirs()) { "Unable to create $this" }
+}
+
 internal fun File.safeCreateNewFile() = apply {
-    check(parentFile.exists() || parentFile.mkdirs()) { "Unable to create $parentFile" }
+    parentFile.safeMkdirs()
     check(exists() || createNewFile()) { "Unable to create $this" }
 }
+
+internal fun File.readProcessed(maxLength: Int) =
+        readText().normalized().throwOnOverflow(maxLength, this)
 
 internal fun String.normalized() = replace(Regex("\\r\\n"), "\n").trim()
 

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/PlayPublishPackageBase.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/PlayPublishPackageBase.kt
@@ -18,12 +18,12 @@ abstract class PlayPublishPackageBase : PlayPublishTaskBase() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:Optional
     @get:InputDirectory
-    internal val releaseNotesDir by lazy { File(resDir, RELEASE_NOTES_PATH).orNull() }
+    internal val releaseNotesDir by lazy { File(resDir, RELEASE_NOTES_PATH) }
 
     protected fun AndroidPublisher.Edits.updateTracks(editId: String, versions: List<Long>) {
         progressLogger.progress("Updating tracks")
 
-        val releaseTexts = releaseNotesDir?.listFiles()?.mapNotNull { locale ->
+        val releaseTexts = releaseNotesDir.listFiles()?.mapNotNull { locale ->
             val file = File(locale, extension.track).orNull()
                     ?: File(locale, RELEASE_NOTES_DEFAULT_NAME).orNull()
                     ?: return@mapNotNull null

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/PlayPublishPackageBase.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/PlayPublishPackageBase.kt
@@ -5,22 +5,25 @@ import com.google.api.services.androidpublisher.model.LocalizedText
 import com.google.api.services.androidpublisher.model.Track
 import com.google.api.services.androidpublisher.model.TrackRelease
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import java.io.File
 
 abstract class PlayPublishPackageBase : PlayPublishTaskBase() {
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @get:Internal internal lateinit var resDir: File
+
+    @Suppress("MemberVisibilityCanBePrivate", "unused") // Used by Gradle
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:Optional
     @get:InputDirectory
-    internal lateinit var releaseNotesDir: File
+    internal val releaseNotesDir by lazy { File(resDir, RELEASE_NOTES_PATH).orNull() }
 
     protected fun AndroidPublisher.Edits.updateTracks(editId: String, versions: List<Long>) {
-        val track = tracks()
-                .list(variant.applicationId, editId)
-                .execute().tracks
-                ?.firstOrNull { it.track == extension.track } ?: Track()
+        progressLogger.progress("Updating tracks")
 
-        val releaseTexts = releaseNotesDir.orNull()?.listFiles()?.mapNotNull { locale ->
+        val releaseTexts = releaseNotesDir?.listFiles()?.mapNotNull { locale ->
             val file = File(locale, extension.track).orNull()
                     ?: File(locale, RELEASE_NOTES_DEFAULT_NAME).orNull()
                     ?: return@mapNotNull null
@@ -41,8 +44,10 @@ abstract class PlayPublishPackageBase : PlayPublishTaskBase() {
             versionCodes = versions
         }
 
-        track.releases = listOf(trackRelease)
-
+        val track = Track().apply {
+            track = extension.track
+            releases = listOf(trackRelease)
+        }
         tracks()
                 .update(variant.applicationId, editId, extension.track, track)
                 .execute()

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/GenerateResources.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/GenerateResources.kt
@@ -121,6 +121,11 @@ open class GenerateResources : DefaultTask() {
         validateReleaseNotes()
     }
 
+    /**
+     * See https://github.com/gradle/gradle/issues/2016 to understand why this is necessary.
+     * Evaluation happens too early which means we either crash or our directories are ignored. To
+     * circumvent this issue, we simply make sure our inputs always exist.
+     */
     private fun ensureRootsExist() = listOf(
             LISTINGS_PATH,
             RELEASE_NOTES_PATH

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/GenerateResources.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/GenerateResources.kt
@@ -13,6 +13,7 @@ import com.github.triplet.gradle.play.internal.isDirectChildOf
 import com.github.triplet.gradle.play.internal.normalized
 import com.github.triplet.gradle.play.internal.nullOrFull
 import com.github.triplet.gradle.play.internal.orNull
+import com.github.triplet.gradle.play.internal.safeMkdirs
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Internal
@@ -80,6 +81,8 @@ open class GenerateResources : DefaultTask() {
                         }
                     }
         }
+
+        ensureRootsExist()
     }
 
     private fun File.validate() {
@@ -116,6 +119,13 @@ open class GenerateResources : DefaultTask() {
 
         validateListings()
         validateReleaseNotes()
+    }
+
+    private fun ensureRootsExist() = listOf(
+            LISTINGS_PATH,
+            RELEASE_NOTES_PATH
+    ).map { File(resDir, it) }.forEach {
+        it.safeMkdirs()
     }
 
     private fun File.findDest() = File(resDir, toRelativeString(findOwner()))


### PR DESCRIPTION
- Make release notes dir optional (aka don't crash if it isn't there)
   - Remove pointless network call updating tracks
- Update out-of-date credentials annotations

Closes #358