### PR TITLE
Support global CLI options

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -4,6 +4,7 @@ import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.ApplicationVariant
 import com.github.triplet.gradle.play.internal.ACCOUNT_CONFIG
 import com.github.triplet.gradle.play.internal.AccountConfig
+import com.github.triplet.gradle.play.internal.LifecycleHelperTask
 import com.github.triplet.gradle.play.internal.PLAY_PATH
 import com.github.triplet.gradle.play.internal.PlayPublishTaskBase
 import com.github.triplet.gradle.play.internal.RELEASE_NOTES_PATH
@@ -33,21 +34,25 @@ class PlayPublisherPlugin : Plugin<Project> {
         val extension: PlayPublisherExtension =
                 project.extensions.create(PLAY_PATH, PlayPublisherExtension::class.java)
 
-        val bootstrapAllTask = project.newTask<Task>(
+        val bootstrapAllTask = project.newTask<LifecycleHelperTask>(
                 "bootstrap",
-                "Downloads the Play Store listing metadata for all variants."
+                "Downloads the Play Store listing metadata for all variants.",
+                args = *arrayOf(extension)
         )
-        val publishAllTask = project.newTask<Task>(
+        val publishAllTask = project.newTask<LifecycleHelperTask>(
                 "publish",
-                "Uploads APK or App Bundle and all Play Store metadata for every variant."
+                "Uploads APK or App Bundle and all Play Store metadata for every variant.",
+                args = *arrayOf(extension)
         )
-        val publishApkAllTask = project.newTask<Task>(
+        val publishApkAllTask = project.newTask<LifecycleHelperTask>(
                 "publishApk",
-                "Uploads APK for every variant."
+                "Uploads APK for every variant.",
+                args = *arrayOf(extension)
         )
-        val publishListingAllTask = project.newTask<Task>(
+        val publishListingAllTask = project.newTask<LifecycleHelperTask>(
                 "publishListing",
-                "Uploads all Play Store metadata for every variant."
+                "Uploads all Play Store metadata for every variant.",
+                args = *arrayOf(extension)
         )
 
         project.initPlayAccountConfigs(android)
@@ -150,9 +155,10 @@ class PlayPublisherPlugin : Plugin<Project> {
                 }
             }
 
-            project.newTask<Task>(
+            project.newTask<LifecycleHelperTask>(
                     "publish$variantName",
-                    "Uploads all Play Store metadata for $variantName."
+                    "Uploads all Play Store metadata for $variantName.",
+                    args = *arrayOf(extension)
             ) {
                 dependsOn(publishApkTask)
                 dependsOn(publishListingTask)

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/LifecycleHelperTask.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/LifecycleHelperTask.kt
@@ -1,0 +1,9 @@
+package com.github.triplet.gradle.play.internal
+
+import com.github.triplet.gradle.play.PlayPublisherExtension
+import org.gradle.api.DefaultTask
+import javax.inject.Inject
+
+open class LifecycleHelperTask @Inject constructor(
+        override val extension: PlayPublisherExtension
+) : DefaultTask(), ExtensionOptions

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/LifecycleHelperTask.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/LifecycleHelperTask.kt
@@ -2,8 +2,9 @@ package com.github.triplet.gradle.play.internal
 
 import com.github.triplet.gradle.play.PlayPublisherExtension
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Nested
 import javax.inject.Inject
 
 open class LifecycleHelperTask @Inject constructor(
-        override val extension: PlayPublisherExtension
+        @get:Nested override val extension: PlayPublisherExtension
 ) : DefaultTask(), ExtensionOptions

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
@@ -21,8 +21,9 @@ internal inline fun <reified T : Task> Project.newTask(
         name: String,
         description: String,
         group: String? = PLUGIN_GROUP,
+        vararg args: Any?,
         block: T.() -> Unit = {}
-): T = tasks.create(name, T::class.java).apply {
+): T = tasks.create(name, T::class.java, *args).apply {
     this.description = description
     this.group = group
     block()


### PR DESCRIPTION
Supports `./gradlew publish --foo=bar` and the other lifecycle tasks.