### PR TITLE
fix input annotations for account configs

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayAccountConfigExtension.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayAccountConfigExtension.kt
@@ -1,11 +1,7 @@
 package com.github.triplet.gradle.play
 
 import com.github.triplet.gradle.play.internal.AccountConfig
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.*
 import java.io.File
 
 data class PlayAccountConfigExtension @JvmOverloads constructor(
@@ -13,6 +9,6 @@ data class PlayAccountConfigExtension @JvmOverloads constructor(
 
         @get:PathSensitive(PathSensitivity.RELATIVE) @get:InputFile @get:Optional
         override var serviceAccountCredentials: File? = null,
-        @get:PathSensitive(PathSensitivity.RELATIVE) @get:InputFile @get:Optional
+        @get:Input @get:Optional
         override var serviceAccountEmail: String? = null
 ) : AccountConfig

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/AccountConfig.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/AccountConfig.kt
@@ -1,10 +1,6 @@
 package com.github.triplet.gradle.play.internal
 
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.*
 import java.io.File
 
 interface AccountConfig {
@@ -17,11 +13,11 @@ interface AccountConfig {
      */
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFile
+    @get:Optional
     var serviceAccountCredentials: File?
 
     /** Service Account email. Only needed if PKCS12 credentials are used. */
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    @get:InputFile
+    @get:Input
     @get:Optional
     var serviceAccountEmail: String?
 }


### PR DESCRIPTION
This fixes a few annotation errors that made it impossible to actually apply the plugin and run its tasks:

- the service account email is not an `@InputFile`
- credentials file has to be optional as it can be set either through account config or in the play block