### PR TITLE
Validate runtime

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -14,6 +14,7 @@ import com.github.triplet.gradle.play.internal.newTask
 import com.github.triplet.gradle.play.internal.playPath
 import com.github.triplet.gradle.play.internal.set
 import com.github.triplet.gradle.play.internal.validate
+import com.github.triplet.gradle.play.internal.validateRuntime
 import com.github.triplet.gradle.play.tasks.Bootstrap
 import com.github.triplet.gradle.play.tasks.GenerateResources
 import com.github.triplet.gradle.play.tasks.ProcessPackageMetadata
@@ -29,6 +30,8 @@ import java.io.File
 
 class PlayPublisherPlugin : Plugin<Project> {
     override fun apply(project: Project) {
+        validateRuntime()
+
         val android = requireNotNull(project.extensions.get<AppExtension>()) {
             "The 'com.android.application' plugin is required."
         }

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
@@ -2,16 +2,11 @@ package com.github.triplet.gradle.play.internal
 
 import com.android.build.gradle.api.BaseVariant
 import com.android.builder.model.ProductFlavor
-import com.android.builder.model.Version
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.ExtraPropertiesExtension
-import org.gradle.util.GradleVersion
-
-private val MIN_GRADLE_VERSION: GradleVersion = GradleVersion.version("4.1")
-private const val MIN_AGP_VERSION: String = "3.0.1"
 
 internal val BaseVariant.flavorNameOrDefault get() = flavorName.nullOrFull() ?: "main"
 
@@ -37,21 +32,4 @@ internal operator fun ProductFlavor.get(name: String) = extras[name]
 
 internal operator fun ProductFlavor.set(name: String, value: Any?) {
     extras[name] = value
-}
-
-internal fun validateRuntime() {
-    val gradleVersion = GradleVersion.current()
-    check(gradleVersion >= MIN_GRADLE_VERSION) {
-        "Gradle Play Publisher's minimum Gradle version is at least $MIN_GRADLE_VERSION and " +
-                "yours is $gradleVersion. Find the latest version at " +
-                "https://github.com/gradle/gradle/releases, then run " +
-                "'./gradlew wrapper --gradle-version=\$LATEST --distribution-type=ALL'."
-    }
-
-    val agpVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION
-    check(agpVersion >= MIN_AGP_VERSION) {
-        "Gradle Play Publisher's minimum Android Gradle Plugin version is at least " +
-                "$MIN_AGP_VERSION and yours is $agpVersion. Find the latest version and upgrade " +
-                "instructions at https://developer.android.com/studio/releases/gradle-plugin."
-    }
 }

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
@@ -2,11 +2,16 @@ package com.github.triplet.gradle.play.internal
 
 import com.android.build.gradle.api.BaseVariant
 import com.android.builder.model.ProductFlavor
+import com.android.builder.model.Version
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.ExtraPropertiesExtension
+import org.gradle.util.GradleVersion
+
+private val MIN_GRADLE_VERSION: GradleVersion = GradleVersion.version("4.1")
+private const val MIN_AGP_VERSION: String = "3.0.1"
 
 internal val BaseVariant.flavorNameOrDefault get() = flavorName.nullOrFull() ?: "main"
 
@@ -32,4 +37,21 @@ internal operator fun ProductFlavor.get(name: String) = extras[name]
 
 internal operator fun ProductFlavor.set(name: String, value: Any?) {
     extras[name] = value
+}
+
+internal fun validateRuntime() {
+    val gradleVersion = GradleVersion.current()
+    check(gradleVersion >= MIN_GRADLE_VERSION) {
+        "Gradle Play Publisher's minimum Gradle version is at least $MIN_GRADLE_VERSION and " +
+                "yours is $gradleVersion. Find the latest version at " +
+                "https://github.com/gradle/gradle/releases, then run " +
+                "'./gradlew wrapper --gradle-version=\$LATEST --distribution-type=ALL'."
+    }
+
+    val agpVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION
+    check(agpVersion >= MIN_AGP_VERSION) {
+        "Gradle Play Publisher's minimum Android Gradle Plugin version is at least " +
+                "$MIN_AGP_VERSION and yours is $agpVersion. Find the latest version and upgrade " +
+                "instructions at https://developer.android.com/studio/releases/gradle-plugin."
+    }
 }

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Validation.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Validation.kt
@@ -1,9 +1,31 @@
 package com.github.triplet.gradle.play.internal
 
+import com.android.builder.model.Version
 import com.github.triplet.gradle.play.PlayPublisherExtension
+import org.gradle.util.GradleVersion
+
+private val MIN_GRADLE_VERSION: GradleVersion = GradleVersion.version("4.1")
+private const val MIN_AGP_VERSION: String = "3.0.1"
 
 /** Release statuses that are compatible with a [PlayPublisherExtension.track] of `rollout` */
 private val rolloutStatuses = listOf(ReleaseStatus.IN_PROGRESS, ReleaseStatus.HALTED)
+
+internal fun validateRuntime() {
+    val gradleVersion = GradleVersion.current()
+    check(gradleVersion >= MIN_GRADLE_VERSION) {
+        "Gradle Play Publisher's minimum Gradle version is at least $MIN_GRADLE_VERSION and " +
+                "yours is $gradleVersion. Find the latest version at " +
+                "https://github.com/gradle/gradle/releases, then run " +
+                "'./gradlew wrapper --gradle-version=\$LATEST --distribution-type=ALL'."
+    }
+
+    val agpVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION
+    check(agpVersion >= MIN_AGP_VERSION) {
+        "Gradle Play Publisher's minimum Android Gradle Plugin version is at least " +
+                "$MIN_AGP_VERSION and yours is $agpVersion. Find the latest version and upgrade " +
+                "instructions at https://developer.android.com/studio/releases/gradle-plugin."
+    }
+}
 
 /**
  * Check the compatibility of [PlayPublisherExtension.track] and

--- a/plugin/src/test/kotlin/com/github/triplet/gradle/play/CompatibilityTest.kt
+++ b/plugin/src/test/kotlin/com/github/triplet/gradle/play/CompatibilityTest.kt
@@ -110,13 +110,14 @@ class CompatibilityTest(
         @JvmStatic
         @Parameterized.Parameters(name = "agpVersion: {0}, gradleVersion {1}")
         fun parameters() = listOf(
-                // AGP 3.0.1, requires at least gradle 4.1
-                arrayOf("3.0.1", "4.2"),
-                arrayOf("3.0.1", "4.3"),
-                // AGP 3.1.3, requires at least gradle 4.4
+                // AGP 3.0.1 requires at least gradle 4.1
+                arrayOf("3.0.1", "4.1"),
+                // AGP 3.1.3 requires at least gradle 4.4
                 arrayOf("3.1.3", "4.4"),
-                // AGP 3.2.0, requires at least gradle 4.6
+                // AGP 3.2.0 requires at least gradle 4.6
                 arrayOf("3.2.0-beta02", "4.6"),
+
+                // Run against the latest versions
                 arrayOf("3.2.0-beta02", "4.8")
         )
     }


### PR DESCRIPTION
Since we're no longer bundling the AGP, there's no way for us to make sure at least the minimum supported AGP and Gradle versions are being used. This PR adds runtime validation.