### PR TITLE
Fix crash if no release notes are provided

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/PlayPublishPackageBase.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/PlayPublishPackageBase.kt
@@ -20,12 +20,13 @@ abstract class PlayPublishPackageBase : PlayPublishTaskBase() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:Optional
     @get:InputDirectory
-    internal val releaseNotesDir by lazy { File(resDir, RELEASE_NOTES_PATH).safeMkdirs() }
+    internal val releaseNotesDir
+        get() = File(resDir, RELEASE_NOTES_PATH).orNull()
 
     protected fun AndroidPublisher.Edits.updateTracks(editId: String, versions: List<Long>) {
         progressLogger.progress("Updating tracks")
 
-        val releaseTexts = releaseNotesDir.listFiles()?.mapNotNull { locale ->
+        val releaseTexts = releaseNotesDir?.listFiles()?.mapNotNull { locale ->
             val file = File(locale, "${extension.track}.txt").orNull()
                     ?: File(locale, RELEASE_NOTES_DEFAULT_NAME).orNull()
                     ?: return@mapNotNull null


### PR DESCRIPTION
Turns out `lazy` was screwing us over because Gradle checks the property multiple times.