### PR TITLE
Fix deprecations with AGP 3.3

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly("com.android.tools.build:gradle:3.3.0-alpha11")
+    compileOnly("com.android.tools.build:gradle:3.3.0-alpha12")
 
     implementation("com.google.apis:google-api-services-androidpublisher:v3-rev12-1.23.0") {
         exclude("com.google.guava", "guava-jdk5") // Remove when upgrading to AGP 3.1+

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -9,11 +9,7 @@ plugins {
 }
 
 dependencies {
-    // Using compileOnly because every android project applies
-    // its own version of the Android Plugin.
-    // We're staying on 3.0.1 so we don't accidentally use APIs
-    // that are not available in the client project
-    compileOnly("com.android.tools.build:gradle:3.0.1")
+    compileOnly("com.android.tools.build:gradle:3.3.0-alpha11")
 
     implementation("com.google.apis:google-api-services-androidpublisher:v3-rev12-1.23.0") {
         exclude("com.google.guava", "guava-jdk5") // Remove when upgrading to AGP 3.1+

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -141,7 +141,12 @@ class PlayPublisherPlugin : Plugin<Project> {
                     "Processes packaging metadata for $variantName.",
                     null
             ) { init() }
-            checkManifest.dependsOn(processPackageMetadata)
+            try {
+                checkManifestProvider.configure { dependsOn(processPackageMetadata) }
+            } catch (e: NoSuchMethodError) {
+                @Suppress("DEPRECATION")
+                checkManifest.dependsOn(processPackageMetadata)
+            }
 
             val publishApkTask = project.newTask<PublishApk>(
                     "publish${variantName}Apk",
@@ -152,7 +157,12 @@ class PlayPublisherPlugin : Plugin<Project> {
 
                 dependsOn(processPackageMetadata)
                 dependsOn(playResourcesTask)
-                variant.assemble?.let { dependsOn(it) }
+                try {
+                    variant.assembleProvider
+                } catch (e: NoSuchMethodError) {
+                    @Suppress("DEPRECATION")
+                    variant.assemble
+                }?.let { dependsOn(it) }
                         ?: logger.warn("Assemble task not found. Publishing APKs may not work.")
             }
             publishApkAllTask.configure { dependsOn(publishApkTask) }

--- a/plugin/src/test/kotlin/com/github/triplet/gradle/play/CompatibilityTest.kt
+++ b/plugin/src/test/kotlin/com/github/triplet/gradle/play/CompatibilityTest.kt
@@ -112,7 +112,7 @@ class CompatibilityTest(
         fun parameters() = listOf(
                 arrayOf("3.0.1", "4.1"), // Oldest supported
                 arrayOf("3.2.0", "4.6"), // Latest stable
-                arrayOf("3.3.0-alpha12", "4.10") // Latest
+                arrayOf("3.3.0-alpha12", "4.10.1") // Latest
         )
     }
 }

--- a/plugin/src/test/kotlin/com/github/triplet/gradle/play/CompatibilityTest.kt
+++ b/plugin/src/test/kotlin/com/github/triplet/gradle/play/CompatibilityTest.kt
@@ -111,8 +111,8 @@ class CompatibilityTest(
         @Parameterized.Parameters(name = "agpVersion: {0}, gradleVersion {1}")
         fun parameters() = listOf(
                 arrayOf("3.0.1", "4.1"), // Oldest supported
-                arrayOf("3.2.0-rc02", "4.6"), // Latest stable
-                arrayOf("3.3.0-alpha11", "4.10") // Latest
+                arrayOf("3.2.0", "4.6"), // Latest stable
+                arrayOf("3.3.0-alpha12", "4.10") // Latest
         )
     }
 }

--- a/plugin/src/test/kotlin/com/github/triplet/gradle/play/CompatibilityTest.kt
+++ b/plugin/src/test/kotlin/com/github/triplet/gradle/play/CompatibilityTest.kt
@@ -112,7 +112,7 @@ class CompatibilityTest(
         fun parameters() = listOf(
                 arrayOf("3.0.1", "4.1"), // Oldest supported
                 arrayOf("3.2.0-rc02", "4.6"), // Latest stable
-                arrayOf("3.3.0-alpha07", "4.10") // Latest
+                arrayOf("3.3.0-alpha11", "4.10") // Latest
         )
     }
 }


### PR DESCRIPTION
We have the `CompatibilityTest` to make sure things work on older versions.