### PR TITLE
Allow signed variants to be built without creds when resolution strategy is not auto

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/ProcessPackageMetadata.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/ProcessPackageMetadata.kt
@@ -9,14 +9,14 @@ open class ProcessPackageMetadata : PlayPublishTaskBase() {
     init {
         // Always out-of-date since we don't know what's changed on the network
         outputs.upToDateWhen { false }
+
+        onlyIf { extension._resolutionStrategy == ResolutionStrategy.AUTO }
     }
 
     @TaskAction
     fun process() {
         progressLogger.start("Updates APK/Bundle metadata for variant ${variant.name}", null)
-
-        if (extension._resolutionStrategy == ResolutionStrategy.AUTO) processVersionCodes()
-
+        processVersionCodes()
         progressLogger.completed()
     }
 

--- a/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublisherPluginTest.groovy
+++ b/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublisherPluginTest.groovy
@@ -9,6 +9,7 @@ import org.junit.Test
 
 import static DependsOn.dependsOn
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertThat
 import static org.junit.Assert.assertTrue
@@ -461,5 +462,16 @@ class PlayPublisherPluginTest {
         assertThat(project.tasks.publish, dependsOn('publishProductionPaidRelease'))
         assertThat(project.tasks.publishApk, dependsOn('publishProductionPaidReleaseApk'))
         assertThat(project.tasks.publishListing, dependsOn('publishProductionPaidReleaseListing'))
+    }
+
+    @Test
+    void signedBuildsCanBeAssembledWithoutCredsWhenResStratNotAuto() {
+        def project = TestHelper.evaluatableProject()
+        project.evaluate()
+
+        def processTask = project.tasks.processReleaseMetadata
+        processTask.execute() // Hack: we should be using the GradleRunner to run a real build
+
+        assertFalse(processTask.didWork)
     }
 }


### PR DESCRIPTION
Fixes #387