### PR TITLE
Circumvent task name conflicts by prefixing names with "gpp" should one occur

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
@@ -36,10 +36,11 @@ internal inline fun <reified T : Task> Project.newTask(
         block()
     }
 
+    val safeName = if (tasks.findByName(name) == null) name else "gpp" + name.capitalize()
     return if (isConfigurationAvoidanceSupported) {
-        tasks.register(name, config)
+        tasks.register(safeName, config)
     } else {
-        val task = task(name, config)
+        val task = task(safeName, config)
         DefaultProvider { task }
     }
 }


### PR DESCRIPTION
Fixes #427