### PR TITLE
Publish to Gradle Plugin Portal

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -22,6 +22,6 @@ elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
   echo "Skipping snapshot deployment: wrong branch. Expected '$BRANCH' but was '$TRAVIS_BRANCH'."
 else
   echo "Deploying snapshot..."
-  ./gradlew uploadArchives
+  ./gradlew publish
   echo "Snapshot deployed!"
 fi

--- a/README.md
+++ b/README.md
@@ -88,54 +88,15 @@ for GPP to work (go to Settings -> Developer account -> Users & permissions):
 
 ### Installation
 
-In your root `build.gradle(.kts)` file, add the Gradle Play Publisher dependency:
-
-<details open><summary>Kotlin</summary>
-
-```kt
-buildscript {
-    repositories {
-        // ...
-        jcenter()
-    }
-
-    dependencies {
-        // ...
-        classpath("com.github.triplet.gradle:play-publisher:2.0.0-beta2")
-    }
-}
-```
-
-</details>
-
-<details><summary>Groovy</summary>
-
-```groovy
-buildscript {
-    repositories {
-        // ...
-        jcenter()
-    }
-
-    dependencies {
-        // ...
-        classpath 'com.github.triplet.gradle:play-publisher:2.0.0-beta2'
-    }
-}
-```
-
-</details>
-</br>
-
-Then apply it to each individual `com.android.application` module where you want to use GPP.
-For example, `app/build.gradle(.kts)` is a commonly used app module:
+Apply the plugin to each individual `com.android.application` module where you want to use GPP
+through the `plugins {}` DSL:
 
 <details open><summary>Kotlin</summary>
 
 ```kt
 plugins {
     id("com.android.application")
-    id("com.github.triplet.play")
+    id("com.github.triplet.play") version "2.0.0-rc2"
 }
 ```
 
@@ -144,8 +105,10 @@ plugins {
 <details><summary>Groovy</summary>
 
 ```groovy
-apply plugin: 'com.android.application'
-apply plugin: 'com.github.triplet.play'
+plugins {
+    id 'com.android.application'
+    id 'com.github.triplet.play' version '2.0.0-rc2'
+}
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
         <img src="https://img.shields.io/travis/Triple-T/gradle-play-publisher/master.svg?style=flat-square" />
     </a>
     <a href="https://search.maven.org/search?q=g:com.github.triplet.gradle%20AND%20a:play-publisher&core=gav">
-        <img src="https://maven-badges.herokuapp.com/maven-central/com.github.triplet.gradle/play-publisher/badge.svg" />
+        <img src="https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/github/triplet/play/com.github.triplet.play.gradle.plugin/maven-metadata.xml.svg?label=Gradle%20Plugins%20Portal" />
     </a>
 </p>
 
 Gradle Play Publisher is a Gradle plugin that allows you to upload your App Bundle or APK and other
 app details to the Google Play Store.
 
-> **Note:** this README targets the `v2.0.0` betas. Documentation for the latest stable release is
+> **Note:** this README targets the `v2.0.0` betas and release candidates. Documentation for the latest stable release is
 available [here](https://github.com/Triple-T/gradle-play-publisher/blob/1.2.2/README.md).
 
 ## Table of contents

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,6 @@ buildscript {
         google()
         jcenter()
     }
-
-    dependencies {
-        classpath("com.vanniktech:gradle-maven-publish-plugin:0.2.0")
-    }
 }
 
 plugins {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,20 +2,3 @@ org.gradle.jvmargs=-Xmx6g -XX:ReservedCodeCacheSize=2g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.caching=true
-
-GROUP=com.github.triplet.gradle
-VERSION_NAME=2.0.0-rc1
-
-POM_DESCRIPTION=Gradle Plugin to upload APKs and App Bundles to the Google Play Store
-
-POM_URL=https://github.com/Triple-T/gradle-play-publisher
-POM_SCM_URL=https://github.com/Triple-T/gradle-play-publisher
-POM_SCM_CONNECTION=scm:git@github.com:Triple-T/gradle-play-publisher.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com:Triple-T/gradle-play-publisher.git
-
-POM_LICENCE_NAME=The MIT License (MIT)
-POM_LICENCE_URL=http://opensource.org/licenses/MIT
-POM_LICENCE_DIST=repo
-
-POM_DEVELOPER_ID=Triple-T
-POM_DEVELOPER_NAME=Triple-T-Dev

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,11 +1,11 @@
-import org.codehaus.groovy.runtime.InvokerHelper
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
 
 plugins {
     `java-gradle-plugin`
     `kotlin-dsl`
+    `maven-publish`
     groovy
-    id("com.vanniktech.maven.publish")
+    id("com.gradle.plugin-publish") version "0.10.0"
 }
 
 dependencies {
@@ -33,29 +33,104 @@ tasks.withType<KotlinJvmCompile> {
     }
 }
 
+group = "com.github.triplet.gradle"
+version = "2.0.0-beta1"
+
 gradlePlugin {
-    plugins {
-        create("play") {
-            id = "com.github.triplet.play"
-            implementationClass = "com.github.triplet.gradle.play.PlayPublisherPlugin"
+    plugins.create("play") {
+        id = "com.github.triplet.play"
+        displayName = "Gradle Play Publisher"
+        description = "Gradle Play Publisher allows you to upload your App Bundle or APK " +
+                "and other app details to the Google Play Store."
+        implementationClass = "com.github.triplet.gradle.play.PlayPublisherPlugin"
+    }
+}
+
+pluginBundle {
+    website = "https://github.com/Triple-T/gradle-play-publisher"
+    vcsUrl = "https://github.com/Triple-T/gradle-play-publisher"
+    tags = listOf("android", "google-play")
+
+    mavenCoordinates {
+        groupId = project.group as String
+        artifactId = "play-publisher"
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "Snapshots"
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+
+            credentials {
+                username = project.findProperty("SONATYPE_NEXUS_USERNAME")?.toString()
+                password = project.findProperty("SONATYPE_NEXUS_PASSWORD")?.toString()
+            }
         }
     }
 }
 
-afterEvaluate {
-    fun PomFilterContainer.removeTestDependencies() {
-        pom.whenConfigured {
-            dependencies.removeIf {
-                // Stolen from JetBrains' own sample at
-                // https://github.com/JetBrains/kotlin/blob/v1.2.50/buildSrc/src/main/kotlin/plugins/PublishedKotlinModule.kt#L86
-                InvokerHelper.getMetaClass(it).getProperty(it, "scope") == "test"
-            }
-        }
-    }
+val sourcesJar by tasks.registering(Jar::class) {
+    classifier = "sources"
+    from(sourceSets["main"].allSource)
+    dependsOn(tasks["classes"])
+}
 
-    tasks.withType<Upload> {
-        repositories.forEach {
-            (it as? PomFilterContainer)?.removeTestDependencies()
+afterEvaluate {
+    publishing.publications.named<MavenPublication>("pluginMaven") {
+        artifactId = "play-publisher"
+        artifact(sourcesJar.get())
+
+        pom {
+            name.set("Google Play Publisher")
+            description.set("Gradle Play Publisher is a plugin that allows you to upload your " +
+                                    "App Bundle or APK and other app details to the " +
+                                    "Google Play Store.")
+            url.set("https://github.com/Triple-T/gradle-play-publisher")
+
+            licenses {
+                license {
+                    name.set("The MIT License (MIT)")
+                    url.set("http://opensource.org/licenses/MIT")
+                    distribution.set("repo")
+                }
+            }
+
+            developers {
+                developer {
+                    id.set("bhurling")
+                    name.set("Björn Hurling")
+                    roles.set(listOf("Owner"))
+                    timezone.set("+2")
+                }
+                developer {
+                    id.set("SUPERCILEX")
+                    name.set("Alex Saveau")
+                    email.set("saveau.alexandre@gmail.com")
+                    roles.set(listOf("Developer"))
+                    timezone.set("-8")
+                }
+                developer {
+                    id.set("ChristianBecker")
+                    name.set("Christian Becker")
+                    email.set("christian.becker.1987@gmail.com")
+                    roles.set(listOf("Developer"))
+                    timezone.set("+2")
+                }
+                developer {
+                    id.set("gtcompscientist")
+                    name.set("Charles Anderson")
+                    roles.set(listOf("Developer"))
+                    timezone.set("-8")
+                }
+            }
+
+            scm {
+                connection.set("scm:git@github.com:Triple-T/gradle-play-publisher.git")
+                developerConnection.set("scm:git@github.com:Triple-T/gradle-play-publisher.git")
+                url.set("https://github.com/Triple-T/gradle-play-publisher")
+            }
         }
     }
 }
@@ -64,8 +139,6 @@ tasks.withType<Test> {
     // Our integration tests need a fully compiled jar
     dependsOn("assemble")
 
-    // Those tests also need to know which version code was built
-    project.property("VERSION_NAME")?.let {
-        systemProperty("VERSION_NAME", it)
-    }
+    // Those tests also need to know which version was built
+    systemProperty("VERSION_NAME", version)
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -34,7 +34,7 @@ tasks.withType<KotlinJvmCompile> {
 }
 
 group = "com.github.triplet.gradle"
-version = "2.0.0-beta1"
+version = "2.0.0-rc2"
 
 gradlePlugin {
     plugins.create("play") {

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,3 +1,0 @@
-POM_NAME=Google Play Publisher Gradle Plugin
-POM_ARTIFACT_ID=play-publisher
-POM_PACKAGING=jar

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -1,6 +1,7 @@
 package com.github.triplet.gradle.play
 
 import com.android.build.gradle.AppExtension
+import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.internal.api.InstallableVariantImpl
 import com.github.triplet.gradle.play.internal.PLAY_PATH
 import com.github.triplet.gradle.play.internal.configure
@@ -26,15 +27,19 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.the
+import org.gradle.kotlin.dsl.withType
 
 @Suppress("unused") // Used by Gradle
 class PlayPublisherPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         validateRuntime()
 
-        val android = requireNotNull(project.the<AppExtension>()) {
-            "The 'com.android.application' plugin is required."
+        project.plugins.withType<AppPlugin> {
+            applyInternal(project)
         }
+    }
+
+    private fun applyInternal(project: Project) {
         val baseExtension: PlayPublisherExtension =
                 project.extensions.create(PLAY_PATH, PlayPublisherExtension::class.java)
         val extensionContainer = project.container(PlayPublisherExtension::class.java)
@@ -68,6 +73,7 @@ class PlayPublisherPlugin : Plugin<Project> {
                 "Uploads all Play Store in-app products for every variant."
         ) { extension = baseExtension }
 
+        val android = project.the<AppExtension>()
         (android as ExtensionAware).extensions.add("playConfigs", extensionContainer)
         BootstrapOptionsHolder.reset()
         android.applicationVariants.whenObjectAdded {

--- a/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublisherPluginTest.groovy
+++ b/plugin/src/test/groovy/com/github/triplet/gradle/play/PlayPublisherPluginTest.groovy
@@ -3,8 +3,6 @@ package com.github.triplet.gradle.play
 import com.github.triplet.gradle.play.internal.ReleaseStatus
 import com.github.triplet.gradle.play.internal.TrackType
 import org.gradle.api.ProjectConfigurationException
-import org.gradle.api.internal.plugins.PluginApplicationException
-import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Test
 
 import static DependsOn.dependsOn
@@ -15,13 +13,6 @@ import static org.junit.Assert.assertThat
 import static org.junit.Assert.assertTrue
 
 class PlayPublisherPluginTest {
-
-    @Test(expected = PluginApplicationException.class)
-    void testThrowsOnLibraryProjects() {
-        def project = ProjectBuilder.builder().build()
-        project.apply plugin: 'com.android.library'
-        project.apply plugin: 'com.github.triplet.play'
-    }
 
     @Test
     void testCreatesDefaultTask() {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,3 @@
 include(":plugin")
+
+enableFeaturePreview("STABLE_PUBLISHING")


### PR DESCRIPTION
#154

Publishing to Gradle Plugin Portal:
`./gradlew publishPlugins -Pgradle.publish.key=<key> -Pgradle.publish.secret=<secret>`

Complete guide [here](https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/).

Publishing to mavenLocal:
`./gradlew publishToMavenLocal`

Using from mavenLocal:
```gradle
// settings.gradle:
pluginManagement {
    repositories {
        gradlePluginPortal()
        mavenLocal()
    }
}

// build.gradle:
plugins {
    id "com.android.application"
    id "com.github.triplet.play" version "2.0.0-SNAPSHOT" // Snapshots require Gradle 4.10+
}
```

POM is the same as before.
Javadoc jar is no longer published because it was empty.

Publishing snapshots to Sonatype should theoretically work if `SONATYPE_NEXUS_USERNAME` and `SONATYPE_NEXUS_PASSWORD` are provided but I can't test it right now.