### PR TITLE
Ignore application not found errors during metadata processing

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Validation.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Validation.kt
@@ -2,6 +2,7 @@ package com.github.triplet.gradle.play.internal
 
 import com.android.builder.model.Version
 import com.github.triplet.gradle.play.PlayPublisherExtension
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import org.gradle.util.GradleVersion
 
 private val MIN_GRADLE_VERSION: GradleVersion = GradleVersion.version("4.1")
@@ -48,3 +49,6 @@ internal fun PlayPublisherExtension.validate() {
         }
     }
 }
+
+internal infix fun GoogleJsonResponseException.has(error: String) =
+        details?.errors.orEmpty().any { it.reason == error }

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/ProcessPackageMetadata.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/ProcessPackageMetadata.kt
@@ -20,7 +20,7 @@ open class ProcessPackageMetadata : PlayPublishTaskBase() {
         progressLogger.completed()
     }
 
-    private fun processVersionCodes() = read { editId ->
+    private fun processVersionCodes() = read(true) { editId ->
         progressLogger.progress("Downloading active version codes")
         val maxVersionCode = tracks().list(variant.applicationId, editId).execute().tracks
                 ?.map { it.releases ?: emptyList() }?.flatten()

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishApk.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishApk.kt
@@ -62,7 +62,7 @@ open class PublishApk : PlayPublishPackageBase() {
                     .trackUploadProgress(progressLogger, "APK")
                     .execute()
         } catch (e: GoogleJsonResponseException) {
-            return e.handleUploadFailures(content.file)
+            return handleUploadFailures(e, content.file)
         }
 
         handlePackageDetails(editId, apk.versionCode)

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishBundle.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishBundle.kt
@@ -59,7 +59,7 @@ open class PublishBundle : PlayPublishPackageBase() {
                     .trackUploadProgress(progressLogger, "App Bundle")
                     .execute()
         } catch (e: GoogleJsonResponseException) {
-            return e.handleUploadFailures(content.file)
+            return handleUploadFailures(e, content.file)
         }
 
         handlePackageDetails(editId, bundle.versionCode)

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishListing.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishListing.kt
@@ -6,6 +6,7 @@ import com.github.triplet.gradle.play.internal.ImageType
 import com.github.triplet.gradle.play.internal.LISTINGS_PATH
 import com.github.triplet.gradle.play.internal.ListingDetail
 import com.github.triplet.gradle.play.internal.climbUpTo
+import com.github.triplet.gradle.play.internal.has
 import com.github.triplet.gradle.play.internal.isDirectChildOf
 import com.github.triplet.gradle.play.internal.orNull
 import com.github.triplet.gradle.play.internal.playPath
@@ -123,7 +124,7 @@ open class PublishListing : PlayPublishTaskBase() {
         try {
             listings().update(variant.applicationId, editId, locale, listing).execute()
         } catch (e: GoogleJsonResponseException) {
-            if (e.details?.errors.orEmpty().any { it.reason == "unsupportedListingLanguage" }) {
+            if (e has "unsupportedListingLanguage") {
                 // Rethrow for clarity
                 throw IllegalArgumentException("Unsupported locale $locale", e)
             } else {

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayPublishTaskBase.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayPublishTaskBase.kt
@@ -4,6 +4,7 @@ import com.android.build.gradle.api.ApplicationVariant
 import com.github.triplet.gradle.play.PlayPublisherExtension
 import com.github.triplet.gradle.play.internal.AccountConfig
 import com.github.triplet.gradle.play.internal.PLUGIN_NAME
+import com.github.triplet.gradle.play.internal.has
 import com.github.triplet.gradle.play.internal.transport
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
@@ -64,7 +65,7 @@ abstract class PlayPublishTaskBase : DefaultTask(), ExtensionOptions {
         val id = try {
             request.execute().id
         } catch (e: GoogleJsonResponseException) {
-            if (e.isApplicationNotFound) {
+            if (e has "applicationNotFound") {
                 if (skipIfNotFound) {
                     return
                 } else {
@@ -88,7 +89,4 @@ abstract class PlayPublishTaskBase : DefaultTask(), ExtensionOptions {
         block(it)
         commit(variant.applicationId, it).execute()
     }
-
-    private val GoogleJsonResponseException.isApplicationNotFound
-        get() = details?.errors.orEmpty().any { it.reason == "applicationNotFound" }
 }

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayPublishTaskBase.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayPublishTaskBase.kt
@@ -54,7 +54,10 @@ abstract class PlayPublishTaskBase : DefaultTask(), ExtensionOptions {
         }.setApplicationName(PLUGIN_NAME).build()
     }
 
-    protected fun read(skipIfNotFound: Boolean = false, block: AndroidPublisher.Edits.(editId: String) -> Unit) {
+    protected fun read(
+            skipIfNotFound: Boolean = false,
+            block: AndroidPublisher.Edits.(editId: String) -> Unit
+    ) {
         val edits = publisher.edits()
         val request = edits.insert(variant.applicationId, null)
 
@@ -63,7 +66,7 @@ abstract class PlayPublishTaskBase : DefaultTask(), ExtensionOptions {
         } catch (e: GoogleJsonResponseException) {
             if (e.isApplicationNotFound) {
                 if (skipIfNotFound) {
-                    null
+                    return
                 } else {
                     // Rethrow for clarity
                     throw IllegalArgumentException(
@@ -78,10 +81,7 @@ abstract class PlayPublishTaskBase : DefaultTask(), ExtensionOptions {
             }
         }
 
-        // If application wasn't found we might want to skip calling the block altogether
-        if (id != null) {
-            edits.block(id)
-        }
+        edits.block(id)
     }
 
     protected fun write(block: AndroidPublisher.Edits.(editId: String) -> Unit) = read {


### PR DESCRIPTION
Fixes #441

When using `ResolutionStrategy.AUTO` there still might be flavors that are not supposed to be published. Processing the package metadata would fail the build. However, we don't know that a flavor isn't published until we've tried