### PR TITLE
Move promote validation before track selection

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PromoteRelease.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PromoteRelease.kt
@@ -13,7 +13,11 @@ open class PromoteRelease : PlayPublishPackageBase() {
     fun promote() = write { editId: String ->
         progressLogger.start("Promotes artifacts for variant ${variant.name}", null)
 
-        val tracks = tracks().list(variant.applicationId, editId).execute().tracks.orEmpty()
+        val tracks = tracks().list(variant.applicationId, editId).execute()
+                .tracks.orEmpty()
+                .filter {
+                    it.releases.orEmpty().flatMap { it.versionCodes.orEmpty() }.isNotEmpty()
+                }
 
         if (tracks.isEmpty()) {
             logger.warn("Nothing to promote. Did you mean to run publish?")
@@ -30,9 +34,6 @@ open class PromoteRelease : PlayPublishPackageBase() {
                     "${name.capitalize()} track has no active artifacts"
                 }
             }
-        }
-        check(track.releases.orEmpty().map { it.versionCodes.orEmpty() }.flatten().isNotEmpty()) {
-            "${track.track.capitalize()} track has no releases"
         }
         progressLogger.progress("Promoting '${track.track}' release to '${extension.track}'")
 


### PR DESCRIPTION
Our current validation fails the task if we receive unexpected responses from the publisher API. Instead, we should filter out these responses so that only valid tracks are selected or the task fails softly with a warning where there are no valid tracks.