### PR TITLE
Reduce confusion around "inProgress" naming in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ artifacts.
 Several options are available to customize how your artifacts are published:
 
 * `track` is the target stage for an artifact, i.e. alpha/beta/prod
-* `releaseStatus` is the type of release, i.e. draft/completed/in progress
+* `releaseStatus` is the type of release, i.e. draft/completed/inProgress
 * `userFraction` is the percentage of users who will received a staged release
 
 Example configuration:


### PR DESCRIPTION
Right now, the README.md introduces "in progress" and "inProgress", and the reader has to wonder about which one is the correct one. Let's talk just about `inProgress`, to avoid confusion.