### PR TITLE
Fix broken app bundle uploading

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishApk.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishApk.kt
@@ -24,7 +24,6 @@ open class PublishApk : PlayPublishPackageBase() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles
     protected val inputApks by lazy {
-        // TODO: If we take a customizable folder, we can fix #233, #227
         variant.outputs.filterIsInstance<ApkVariantOutput>().filter {
             OutputType.valueOf(it.outputType) == OutputType.MAIN || it.filters.isNotEmpty()
         }.map { it.outputFile }

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishBundle.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishBundle.kt
@@ -1,5 +1,7 @@
 package com.github.triplet.gradle.play.tasks
 
+import com.android.build.gradle.internal.api.InstallableVariantImpl
+import com.android.build.gradle.internal.scope.InternalArtifactType
 import com.github.triplet.gradle.play.internal.MIME_TYPE_STREAM
 import com.github.triplet.gradle.play.internal.playPath
 import com.github.triplet.gradle.play.internal.trackUploadProgress
@@ -21,9 +23,8 @@ open class PublishBundle : PlayPublishPackageBase() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFile
     val bundle by lazy {
-        // TODO: If we take a customizable folder, we can fix #233, #227
-        val archivesBaseName = project.properties["archivesBaseName"] as String
-        File(project.buildDir, "outputs/bundle/${variant.name}/${archivesBaseName}.aab")
+        (variant as InstallableVariantImpl).getFinalArtifact(InternalArtifactType.BUNDLE)
+                .files.single()
     }
     @Suppress("MemberVisibilityCanBePrivate", "unused") // Used by Gradle
     @get:PathSensitive(PathSensitivity.RELATIVE)


### PR DESCRIPTION
Fixes #516

Googler's response:
> Unfortunately there is no way to get that using the variant API. Other than hardcoding the bundle path, there is one (slightly hacky) option: ...

Basically, there's no stable way to get the bundle path. I've checked and this API works all the way back to 3.2 when AGP added bundles so I think we're good. We'll just have to fix things again when they break.