### PR TITLE
Always run `outputProcessor` if resolution strategy is set to auto

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/ProcessPackageMetadata.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/ProcessPackageMetadata.kt
@@ -32,10 +32,8 @@ open class ProcessPackageMetadata : PlayPublishTaskBase() {
         val smallestVersionCode = outputs.map { it.versionCode }.min() ?: 1
 
         val patch = maxVersionCode - smallestVersionCode + 1
-        if (patch <= 0) return@read // Nothing to do, outputs are already greater than remote
-
         for ((i, output) in outputs.withIndex()) {
-            output.versionCodeOverride = output.versionCode + patch.toInt() + i
+            if (patch > 0) output.versionCodeOverride = output.versionCode + patch.toInt() + i
             extension._outputProcessor?.execute(output)
         }
     }


### PR DESCRIPTION
Fixes #531