### PR TITLE
Permanently fix timeout issues

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PublishingApi.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PublishingApi.kt
@@ -31,10 +31,7 @@ internal fun PlayPublisherExtension.buildPublisher(): AndroidPublisher {
     }
 
     return AndroidPublisher.Builder(transport, JacksonFactory.getDefaultInstance()) {
-        credential.initialize(it.apply {
-            readTimeout = 300_000
-            connectTimeout = 300_000
-        })
+        credential.initialize(it.apply { readTimeout = 0 })
     }.setApplicationName(PLUGIN_NAME).build()
 }
 

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PublishingApi.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PublishingApi.kt
@@ -31,7 +31,7 @@ internal fun PlayPublisherExtension.buildPublisher(): AndroidPublisher {
     }
 
     return AndroidPublisher.Builder(transport, JacksonFactory.getDefaultInstance()) {
-        credential.initialize(it.apply { readTimeout = 0 })
+        credential.initialize(it.setReadTimeout(0))
     }.setApplicationName(PLUGIN_NAME).build()
 }
 


### PR DESCRIPTION
Over time, we've been continuously increasing the timeout without much success (people still run into timeout exceptions). The main problem is that the Publisher API makes us wait for it to do all sorts of processing and validation synchronously. This means we're at the mercy of however long it takes the API to do its thing. Given all the uncertainty, this PR makes the timeout indefinite. Worst case scenario, devs will just have to manually kill a stalled build.