### PR TITLE
Make BuildConfig generation wait on output processors

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -159,9 +159,12 @@ class PlayPublisherPlugin : Plugin<Project> {
             ) { init() }
             try {
                 checkManifestProvider.configure { dependsOn(processPackageMetadata) }
+                generateBuildConfigProvider.configure { dependsOn(processPackageMetadata) }
             } catch (e: NoSuchMethodError) {
                 @Suppress("DEPRECATION")
                 checkManifest.dependsOnCompat(processPackageMetadata)
+                @Suppress("DEPRECATION")
+                generateBuildConfig.dependsOnCompat(processPackageMetadata)
             }
 
             val publishApkTask = project.newTask<PublishApk>(


### PR DESCRIPTION
Fixes #553