### PR TITLE
Make artifactDir property accept files

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishApk.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishApk.kt
@@ -40,6 +40,8 @@ abstract class PublishApk @Inject constructor(
 
             return if (customDir == null) {
                 variant.outputs.filterIsInstance<ApkVariantOutput>().map { it.outputFile }
+            } else if (customDir.isFile && customDir.extension == "apk") {
+                listOf(customDir)
             } else {
                 customDir.listFiles().orEmpty().filter { it.extension == "apk" }.also {
                     if (it.isEmpty()) logger.warn("Warning: no APKs found in '$customDir' yet.")

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishInternalSharingApk.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishInternalSharingApk.kt
@@ -38,6 +38,8 @@ abstract class PublishInternalSharingApk @Inject constructor(
                 variant.outputs.filterIsInstance<ApkVariantOutput>().singleOrNull {
                     OutputType.valueOf(it.outputType) == OutputType.MAIN || it.filters.isEmpty()
                 }?.outputFile
+            } else if (customDir.isFile && customDir.extension == "apk") {
+                customDir
             } else {
                 customDir.listFiles().orEmpty().singleOrNull { it.extension == "apk" }.also {
                     if (it == null) logger.warn("Warning: no APKs found in '$customDir' yet.")

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/Agp.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/Agp.kt
@@ -25,6 +25,8 @@ fun PlayPublishTaskBase.findBundleFile(): File? {
         installable.variantData.scope.artifacts
                 .getFinalProduct<RegularFile>(InternalArtifactType.BUNDLE)
                 .get().asFile.orNull() ?: getFinalArtifactCompat().singleOrNull()
+    } else if (customDir.isFile && customDir.extension == "aab") {
+        customDir
     } else {
         customDir.listFiles().orEmpty().singleOrNull { it.extension == "aab" }.also {
             if (it == null) logger.warn("Warning: no App Bundle found in '$customDir' yet.")


### PR DESCRIPTION
It's super easy to make a mistake when tabbing to find a file. Usually, you have to delete the file name to get back to the directory that GPP will understand. This is annoying, so GPP should be lenient and accept those files if they seem correct.