### PR TITLE
Fix extension merging bugs

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -8,7 +8,7 @@ import com.github.triplet.gradle.play.internal.PLAY_PATH
 import com.github.triplet.gradle.play.internal.ResolutionStrategy
 import com.github.triplet.gradle.play.internal.getCommitEditTask
 import com.github.triplet.gradle.play.internal.getGenEditTask
-import com.github.triplet.gradle.play.internal.mergeWith
+import com.github.triplet.gradle.play.internal.mergeExtensions
 import com.github.triplet.gradle.play.internal.newTask
 import com.github.triplet.gradle.play.internal.playPath
 import com.github.triplet.gradle.play.internal.resolutionStrategyOrDefault
@@ -114,11 +114,20 @@ class PlayPublisherPlugin : Plugin<Project> {
                 return@whenObjectAdded
             }
 
-            val extension = (extensionContainer.findByName(name) ?: productFlavors.mapNotNull {
-                extensionContainer.findByName(it.name)
-            }.singleOrNull().let {
-                it ?: extensionContainer.findByName(buildType.name)
-            }).mergeWith(baseExtension)
+            val extension = run {
+                val variantExtension = extensionContainer.findByName(name)
+                val flavorExtension = productFlavors.mapNotNull {
+                    extensionContainer.findByName(it.name)
+                }.singleOrNull()
+                val buildTypeExtension = extensionContainer.findByName(buildType.name)
+
+                mergeExtensions(listOfNotNull(
+                        variantExtension,
+                        flavorExtension,
+                        buildTypeExtension,
+                        baseExtension
+                ))
+            }
 
             if (!extension.isEnabled) {
                 project.logger.info("Gradle Play Publisher is disabled for variant '$name'.")

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/ExtensionDefaults.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/ExtensionDefaults.kt
@@ -13,7 +13,7 @@ fun mergeExtensions(extensions: List<PlayPublisherExtension>): PlayPublisherExte
     requireNotNull(extensions.isNotEmpty()) { "At least one extension must be provided." }
     if (extensions.size == 1) return extensions.single()
 
-    var result: PlayPublisherExtension = extensions.first()
+    var result = extensions.first()
     for (i in 1 until extensions.size) {
         result = result.mergeWith(extensions[i])
     }

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/ExtensionDefaults.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/ExtensionDefaults.kt
@@ -9,10 +9,21 @@ internal val PlayPublisherExtension.Config.releaseStatusOrDefault
 internal val PlayPublisherExtension.Config.resolutionStrategyOrDefault
     get() = resolutionStrategy ?: ResolutionStrategy.FAIL
 
-internal fun PlayPublisherExtension?.mergeWith(
-        default: PlayPublisherExtension
+fun mergeExtensions(extensions: List<PlayPublisherExtension>): PlayPublisherExtension {
+    requireNotNull(extensions.isNotEmpty()) { "At least one extension must be provided." }
+    if (extensions.size == 1) return extensions.single()
+
+    var result: PlayPublisherExtension = extensions.first()
+    for (i in 1 until extensions.size) {
+        result = result.mergeWith(extensions[i])
+    }
+    return result
+}
+
+fun PlayPublisherExtension.mergeWith(
+        default: PlayPublisherExtension?
 ): PlayPublisherExtension {
-    if (this == null) return default
+    if (default == null) return this
 
     fun PlayPublisherExtension.getMutableConfig(): Any {
         val field = PlayPublisherExtension::class.java.getDeclaredField("_config")

--- a/plugin/src/test/kotlin/com/github/triplet/gradle/play/PlayPublisherExtensionTest.kt
+++ b/plugin/src/test/kotlin/com/github/triplet/gradle/play/PlayPublisherExtensionTest.kt
@@ -1,0 +1,106 @@
+package com.github.triplet.gradle.play
+
+import com.github.triplet.gradle.play.internal.ReleaseStatus
+import com.github.triplet.gradle.play.internal.ResolutionStrategy
+import com.github.triplet.gradle.play.internal.mergeExtensions
+import com.github.triplet.gradle.play.internal.mergeWith
+import org.junit.Test
+import kotlin.test.assertFails
+
+class PlayPublisherExtensionTest {
+    @Test
+    fun `Config does not share object instance with extension`() {
+        val ext = PlayPublisherExtension().apply { track = "test" }
+        val copy = ext.config
+
+        copy.track = "other"
+
+        assert(ext.track == "test")
+    }
+
+    @Test
+    fun `Merging extension with null returns self`() {
+        val ext = PlayPublisherExtension().apply { track = "test" }
+
+        val merged = ext.mergeWith(null)
+
+        assert(ext === merged)
+    }
+
+    @Test
+    fun `Merging extension with same doesn't change anything`() {
+        val ext = PlayPublisherExtension().apply { track = "test" }
+        val other = PlayPublisherExtension().apply { track = "test" }
+
+        val merged = ext.mergeWith(other)
+
+        assert(ext.config == merged.config)
+    }
+
+    @Test
+    fun `Merging extension with other returns superset`() {
+        val ext = PlayPublisherExtension().apply { track = "test" }
+        val other = PlayPublisherExtension().apply { releaseStatus = "inProgress" }
+
+        val merged = ext.mergeWith(other)
+
+        assert(merged.config.track == "test")
+        assert(merged.config.releaseStatus == ReleaseStatus.IN_PROGRESS)
+    }
+
+    @Test
+    fun `Merging extensions with empty throws`() {
+        val exts = emptyList<PlayPublisherExtension>()
+
+        assertFails { mergeExtensions(exts) }
+    }
+
+    @Test
+    fun `Merging extensions with single returns self`() {
+        val p0 = PlayPublisherExtension().apply { track = "test" }
+        val exts = listOf(p0)
+
+        val merged = mergeExtensions(exts)
+
+        assert(merged === p0)
+    }
+
+    @Test
+    fun `Merging extensions with multiple returns superset`() {
+        val p0 = PlayPublisherExtension().apply { track = "test" }
+        val p1 = PlayPublisherExtension().apply { releaseStatus = "inProgress" }
+        val exts = listOf(p0, p1)
+
+        val merged = mergeExtensions(exts)
+
+        assert(merged.config.track == "test")
+        assert(merged.config.releaseStatus == ReleaseStatus.IN_PROGRESS)
+    }
+
+    @Test
+    fun `Merging extensions with multiple overlapping returns prioritized superset`() {
+        val p0 = PlayPublisherExtension().apply { track = "test" }
+        val p1 = PlayPublisherExtension().apply {
+            track = "other"
+            releaseStatus = "inProgress"
+        }
+        val p3 = PlayPublisherExtension().apply {
+            releaseStatus = "completed"
+            userFraction = 0.5
+        }
+        val p4 = PlayPublisherExtension().apply {
+            track = "other2"
+            defaultToAppBundles = true
+            resolutionStrategy = "ignore"
+        }
+        val exts = listOf(p0, p1, p3, p4)
+
+        val merged = mergeExtensions(exts)
+
+        assert(merged.config.track == "test")
+        assert(merged.config.releaseStatus == ReleaseStatus.IN_PROGRESS)
+        assert(merged.config.userFraction == 0.5)
+        assert(merged.config.defaultToAppBundles == true)
+        assert(merged.config.resolutionStrategy == ResolutionStrategy.IGNORE)
+    }
+}


### PR DESCRIPTION
Notably, only the base and variant extensions were merged. This meant extensions didn't cascade properly if a user had a combination of variant, flavor, and build type overrides.