### PR TITLE
Bug fixes and improvements around custom internal sharing artifacts

### DIFF
--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishListing.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishListing.kt
@@ -148,7 +148,7 @@ abstract class PublishListing @Inject constructor(
             if (parameters.details.isPresent) {
                 executor.noIsolation().submit(DetailsUploader::class) {
                     parameters.copy(this)
-                    dir.set(parameters.details.get())
+                    dir.set(parameters.details)
                 }
             }
             for (listing in parameters.listings.get()) {

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/Agp.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/Agp.kt
@@ -32,8 +32,12 @@ fun PublishTaskBase.findBundleFile(): File? {
     } else if (customDir.isFile && customDir.extension == "aab") {
         customDir
     } else {
-        customDir.listFiles().orEmpty().singleOrNull { it.extension == "aab" }.also {
-            if (it == null) logger.warn("Warning: no App Bundle found in '$customDir' yet.")
+        val bundles = customDir.listFiles().orEmpty().filter { it.extension == "aab" }
+        if (bundles.isEmpty()) {
+            logger.warn("Warning: '$customDir' does not yet contain an App Bundle.")
+        } else if (bundles.size > 1) {
+            logger.warn("Warning: '$customDir' contains multiple App Bundles. Only one is allowed.")
         }
+        bundles.singleOrNull()
     }
 }

--- a/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/CliOptions.kt
+++ b/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/CliOptions.kt
@@ -4,13 +4,13 @@ import com.github.triplet.gradle.play.PlayPublisherExtension
 import com.github.triplet.gradle.play.internal.ReleaseStatus
 import com.github.triplet.gradle.play.internal.ResolutionStrategy
 import com.github.triplet.gradle.play.internal.orNull
+import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.options.Option
 import org.gradle.api.tasks.options.OptionValues
-import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal interface ExtensionOptionsBase {
@@ -19,6 +19,9 @@ internal interface ExtensionOptionsBase {
 }
 
 internal interface ArtifactExtensionOptions : ExtensionOptionsBase {
+    @Internal
+    fun getProject(): Project
+
     @get:Internal
     @set:Option(
             option = "artifact-dir",
@@ -27,10 +30,10 @@ internal interface ArtifactExtensionOptions : ExtensionOptionsBase {
     var artifactDirOption: String
         get() = throw UnsupportedOperationException()
         set(value) {
-            val dir = File(value)
+            val dir = getProject().rootProject.file(value)
             extension.artifactDir = requireNotNull(dir.orNull()) {
-                "Folder '${dir.absolutePath}' does not exist."
-            }.absoluteFile
+                "Folder '$dir' does not exist."
+            }
         }
 }
 


### PR DESCRIPTION
Fixes #671

Also:
- Allows multiple APKs to be uploaded to internal sharing in the same build.
- Fixes inconsistencies with `--artifact-dir` by always using the rootProject as the relative path