### PR TITLE
Rework line breaks in output messages to be more console friendly

### DIFF
--- a/common/validation/src/main/kotlin/com/github/triplet/gradle/common/validation/RuntimeValidator.kt
+++ b/common/validation/src/main/kotlin/com/github/triplet/gradle/common/validation/RuntimeValidator.kt
@@ -17,19 +17,22 @@ internal class RuntimeValidator(
 
     private fun validateGradle() {
         check(currentGradleVersion >= minGradleVersion) {
-            "Gradle Play Publisher's minimum Gradle version is at least $minGradleVersion and " +
-                    "yours is $currentGradleVersion. Find the latest version at " +
-                    "https://github.com/gradle/gradle/releases, then run " +
-                    "'./gradlew wrapper --gradle-version=\$LATEST --distribution-type=ALL'."
+            """
+            |Gradle Play Publisher's minimum Gradle version is at least $minGradleVersion and yours
+            |is $currentGradleVersion. Find the latest version at
+            |https://github.com/gradle/gradle/releases/latest, then run
+            |$ ./gradlew wrapper --gradle-version=${"$"}LATEST --distribution-type=ALL
+            """.trimMargin()
         }
     }
 
     private fun validateAgp() {
         check(currentAgpVersion >= minAgpVersion) {
-            "Gradle Play Publisher's minimum Android Gradle Plugin version is at least " +
-                    "$minAgpVersion and yours is $currentAgpVersion. Find the latest version " +
-                    "and upgrade instructions at " +
-                    "https://developer.android.com/studio/releases/gradle-plugin."
+            """
+            |Gradle Play Publisher's minimum Android Gradle Plugin version is at least
+            |$minAgpVersion and yours is $currentAgpVersion. Find the latest version and upgrade
+            |instructions at https://developer.android.com/studio/releases/gradle-plugin.
+            """.trimMargin()
         }
         // TODO(#708): remove when 3.6 is the minimum
         check(currentAgpVersion < VersionNumber.parse("3.6.0-alpha01") ||

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -60,44 +60,58 @@ internal class PlayPublisherPlugin : Plugin<Project> {
 
         val bootstrapAllTask = project.newTask<BootstrapLifecycleTask>(
                 "bootstrap",
-                "Downloads the Play Store listing metadata for all variants. See " +
-                        "https://github.com/Triple-T/gradle-play-publisher#quickstart",
+                """
+                |Downloads the Play Store listing metadata for all variants.
+                |   See https://github.com/Triple-T/gradle-play-publisher#quickstart
+                """.trimMargin(),
                 arrayOf(bootstrapOptionsHolder)
         )
         val publishAllTask = project.newTask<GlobalPublishableArtifactLifecycleTask>(
                 "publish",
-                "Uploads APK or App Bundle and all Play Store metadata for every variant. See " +
-                        "https://github.com/Triple-T/gradle-play-publisher#managing-artifacts",
+                """
+                |Uploads APK or App Bundle and all Play Store metadata for every variant.
+                |   See https://github.com/Triple-T/gradle-play-publisher#managing-artifacts
+                """.trimMargin(),
                 arrayOf(baseExtension)
         )
         val publishApkAllTask = project.newTask<PublishableTrackLifecycleTask>(
                 "publishApk",
-                "Uploads APK for every variant. See " +
-                        "https://github.com/Triple-T/gradle-play-publisher#publishing-apks",
+                """
+                |Uploads APK for every variant.
+                |   See https://github.com/Triple-T/gradle-play-publisher#publishing-apks
+                """.trimMargin(),
                 arrayOf(baseExtension)
         )
         val publishBundleAllTask = project.newTask<PublishableTrackLifecycleTask>(
                 "publishBundle",
-                "Uploads App Bundle for every variant. See " +
-                        "https://github.com/Triple-T/gradle-play-publisher#publishing-an-app-bundle",
+                """
+                |Uploads App Bundle for every variant.
+                |   See https://github.com/Triple-T/gradle-play-publisher#publishing-an-app-bundle
+                """.trimMargin(),
                 arrayOf(baseExtension)
         )
         val promoteReleaseAllTask = project.newTask<UpdatableTrackLifecycleTask>(
                 "promoteArtifact",
-                "Promotes a release for every variant. See " +
-                        "https://github.com/Triple-T/gradle-play-publisher#promoting-artifacts",
+                """
+                |Promotes a release for every variant.
+                |   See https://github.com/Triple-T/gradle-play-publisher#promoting-artifacts
+                """.trimMargin(),
                 arrayOf(baseExtension)
         )
         val publishListingAllTask = project.newTask<WriteTrackLifecycleTask>(
                 "publishListing",
-                "Uploads all Play Store metadata for every variant. See " +
-                        "https://github.com/Triple-T/gradle-play-publisher#publishing-listings",
+                """
+                |Uploads all Play Store metadata for every variant.
+                |   See https://github.com/Triple-T/gradle-play-publisher#publishing-listings
+                """.trimMargin(),
                 arrayOf(baseExtension)
         )
         val publishProductsAllTask = project.newTask(
                 "publishProducts",
-                "Uploads all Play Store in-app products for every variant. See " +
-                        "https://github.com/Triple-T/gradle-play-publisher#publishing-in-app-products"
+                """
+                |Uploads all Play Store in-app products for every variant.
+                |   See https://github.com/Triple-T/gradle-play-publisher#publishing-in-app-products
+                """.trimMargin()
         )
 
         // TODO(#709): add tests for validateDebuggability
@@ -130,8 +144,10 @@ internal class PlayPublisherPlugin : Plugin<Project> {
 
             val bootstrapTask = project.newTask<Bootstrap>(
                     "bootstrap$variantName",
-                    "Downloads the Play Store listing metadata for variant '$name'. See " +
-                            "https://github.com/Triple-T/gradle-play-publisher#quickstart",
+                    """
+                    |Downloads the Play Store listing metadata for variant '$name'.
+                    |   See https://github.com/Triple-T/gradle-play-publisher#quickstart
+                    """.trimMargin(),
                     arrayOf(extension, this, bootstrapOptionsHolder)
             ) {
                 srcDir.set(project.file("src/${variant.flavorNameOrDefault}/$PLAY_PATH"))
@@ -164,8 +180,10 @@ internal class PlayPublisherPlugin : Plugin<Project> {
 
             val publishListingTask = project.newTask<PublishListing>(
                     "publish${variantName}Listing",
-                    "Uploads all Play Store metadata for variant '$name'. See " +
-                            "https://github.com/Triple-T/gradle-play-publisher#publishing-listings",
+                    """
+                    |Uploads all Play Store metadata for variant '$name'.
+                    |   See https://github.com/Triple-T/gradle-play-publisher#publishing-listings
+                    """.trimMargin(),
                     arrayOf(extension, this)
             ) {
                 resDir.set(resourceDir)
@@ -183,8 +201,10 @@ internal class PlayPublisherPlugin : Plugin<Project> {
 
             val publishProductsTask = project.newTask<PublishProducts>(
                     "publish${variantName}Products",
-                    "Uploads all Play Store in-app products for variant '$name'. See " +
-                            "https://github.com/Triple-T/gradle-play-publisher#publishing-in-app-products",
+                    """
+                    |Uploads all Play Store in-app products for variant '$name'.
+                    |   See https://github.com/Triple-T/gradle-play-publisher#publishing-in-app-products
+                    """.trimMargin(),
                     arrayOf(extension, this)
             ) {
                 productsDir.setFrom(resourceDir.map {
@@ -218,8 +238,10 @@ internal class PlayPublisherPlugin : Plugin<Project> {
             }
             val publishApkTask = project.newTask<PublishApk>(
                     "publish${variantName}Apk",
-                    "Uploads APK for variant '$name'. See " +
-                            "https://github.com/Triple-T/gradle-play-publisher#publishing-apks",
+                    """
+                    |Uploads APK for variant '$name'.
+                    |   See https://github.com/Triple-T/gradle-play-publisher#publishing-apks
+                    """.trimMargin(),
                     arrayOf(extension, this)
             ) {
                 resDir.set(resourceDir)
@@ -239,8 +261,10 @@ internal class PlayPublisherPlugin : Plugin<Project> {
 
             val publishInternalSharingApkTask = project.newTask<PublishInternalSharingApk>(
                     "upload${variantName}PrivateApk",
-                    "Uploads Internal Sharing APK for variant '$name'. See " +
-                            "https://github.com/Triple-T/gradle-play-publisher#uploading-an-internal-sharing-artifact",
+                    """
+                    |Uploads Internal Sharing APK for variant '$name'.
+                    |   See https://github.com/Triple-T/gradle-play-publisher#uploading-an-internal-sharing-artifact
+                    """.trimMargin(),
                     arrayOf(extension, this)
             ) {
                 outputDirectory.set(project.layout.buildDirectory.dir(
@@ -267,8 +291,10 @@ internal class PlayPublisherPlugin : Plugin<Project> {
             }
             val publishBundleTask = project.newTask<PublishBundle>(
                     "publish${variantName}Bundle",
-                    "Uploads App Bundle for variant '$name'. See " +
-                            "https://github.com/Triple-T/gradle-play-publisher#publishing-an-app-bundle",
+                    """
+                    |Uploads App Bundle for variant '$name'.
+                    |   See https://github.com/Triple-T/gradle-play-publisher#publishing-an-app-bundle
+                    """.trimMargin(),
                     arrayOf(extension, this)
             ) {
                 resDir.set(resourceDir)
@@ -283,8 +309,10 @@ internal class PlayPublisherPlugin : Plugin<Project> {
 
             val publishInternalSharingBundleTask = project.newTask<PublishInternalSharingBundle>(
                     "upload${variantName}PrivateBundle",
-                    "Uploads Internal Sharing App Bundle for variant '$name'. See " +
-                            "https://github.com/Triple-T/gradle-play-publisher#uploading-an-internal-sharing-artifact",
+                    """
+                    |Uploads Internal Sharing App Bundle for variant '$name'.
+                    |   See https://github.com/Triple-T/gradle-play-publisher#uploading-an-internal-sharing-artifact
+                    """.trimMargin(),
                     arrayOf(extension, this)
             ) {
                 outputDirectory.set(project.layout.buildDirectory.dir(
@@ -295,8 +323,10 @@ internal class PlayPublisherPlugin : Plugin<Project> {
 
             val promoteReleaseTask = project.newTask<PromoteRelease>(
                     "promote${variantName}Artifact",
-                    "Promotes a release for variant '$name'. See " +
-                            "https://github.com/Triple-T/gradle-play-publisher#promoting-artifacts",
+                    """
+                    |Promotes a release for variant '$name'.
+                    |   See https://github.com/Triple-T/gradle-play-publisher#promoting-artifacts
+                    """.trimMargin(),
                     arrayOf(extension, this)
             ) {
                 resDir.set(resourceDir)
@@ -313,8 +343,10 @@ internal class PlayPublisherPlugin : Plugin<Project> {
 
             val publishTask = project.newTask<GlobalPublishableArtifactLifecycleTask>(
                     "publish$variantName",
-                    "Uploads APK or App Bundle and all Play Store metadata for variant '$name'. See " +
-                            "https://github.com/Triple-T/gradle-play-publisher#managing-artifacts",
+                    """
+                    |Uploads APK or App Bundle and all Play Store metadata for variant '$name'.
+                    |   See https://github.com/Triple-T/gradle-play-publisher#managing-artifacts
+                    """.trimMargin(),
                     arrayOf(extension)
             ) {
                 dependsOn(if (extension.defaultToAppBundles) publishBundleTask else publishApkTask)
@@ -325,9 +357,10 @@ internal class PlayPublisherPlugin : Plugin<Project> {
 
             project.newTask<InstallInternalSharingArtifact>(
                     "install${variantName}PrivateArtifact",
-                    "Launches an intent to install an Internal Sharing artifact for variant " +
-                            "'$name'. See " +
-                            "https://github.com/Triple-T/gradle-play-publisher#installing-internal-sharing-artifacts",
+                    """
+                    |Launches an intent to install an Internal Sharing artifact for variant '$name'.
+                    |   See https://github.com/Triple-T/gradle-play-publisher#installing-internal-sharing-artifacts
+                    """.trimMargin(),
                     arrayOf(android)
             ) {
                 uploadedArtifacts.set(if (extension.defaultToAppBundles) {

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Validation.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Validation.kt
@@ -9,7 +9,7 @@ import org.gradle.util.DeprecationLogger
 
 internal fun PlayPublisherExtension.validateCreds() {
     val creds = checkNotNull(config.serviceAccountCredentials) {
-        "No credentials specified. Please read our docs for more details: " +
+        "No credentials specified. Please read our docs for more details:\n" +
                 "https://github.com/Triple-T/gradle-play-publisher" +
                 "#authenticating-gradle-play-publisher"
     }
@@ -26,7 +26,7 @@ internal fun PlayPublisherExtension.validateCreds() {
         DeprecationLogger.nagUserWith(
                 "Gradle Play Publisher's PKCS12 based authentication is deprecated.",
                 "This is scheduled to be removed in GPP 3.0.",
-                "Use JSON based authentication instead. " +
+                "Use JSON based authentication instead.\n" +
                         "https://github.com/Triple-T/gradle-play-publisher#service-account",
                 null
         )

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Validation.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Validation.kt
@@ -9,9 +9,10 @@ import org.gradle.util.DeprecationLogger
 
 internal fun PlayPublisherExtension.validateCreds() {
     val creds = checkNotNull(config.serviceAccountCredentials) {
-        "No credentials specified. Please read our docs for more details:\n" +
-                "https://github.com/Triple-T/gradle-play-publisher" +
-                "#authenticating-gradle-play-publisher"
+        """
+        |No credentials specified. Please read our docs for more details:
+        |https://github.com/Triple-T/gradle-play-publisher#authenticating-gradle-play-publisher
+        """.trimMargin()
     }
 
     // TODO(#710): remove once support for PKCS12 creds is gone

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/GenerateEdit.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/GenerateEdit.kt
@@ -75,19 +75,19 @@ internal abstract class GenerateEdit @Inject constructor(
         private fun handleFailure(response: EditResponse.Failure): String {
             if (response.isNewApp()) {
                 // Rethrow for clarity
-                response.rethrow(
-                        "No application found for the package name $appId. " +
-                                "The first version of your app must be uploaded via the " +
-                                "Play Store console.")
+                response.rethrow("""
+                    |No application found for the package name '$appId'. The first version of your
+                    |app must be uploaded via the Play Console.
+                """.trimMargin())
             } else if (response.isInvalidEdit()) {
                 Logging.getLogger(GenerateEdit::class.java)
                         .error("Failed to retrieve saved edit, regenerating.")
                 return getOrCreateEditId()
             } else if (response.isUnauthorized()) {
-                response.rethrow(
-                        "Service account not authenticated. See the README for instructions: " +
-                                "https://github.com/Triple-T/gradle-play-publisher/" +
-                                "blob/master/README.md#service-account")
+                response.rethrow("""
+                    |Service account not authenticated. See the README for instructions:
+                    |https://github.com/Triple-T/gradle-play-publisher#service-account
+                """.trimMargin())
             } else {
                 response.rethrow()
             }


### PR DESCRIPTION
Because of line break it's handled like an invalid url

### Current:
<img width="1419" alt="image" src="https://user-images.githubusercontent.com/3314607/70392144-e6914100-19dc-11ea-96d0-8bd828506eab.png">

### New:
Now the url should be in a new line and be clickable
