### PR TITLE
Allow non-existent mapping files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,8 +36,6 @@ allprojects {
             sourceSets.configureEach {
                 languageSettings.progressiveMode = true
                 languageSettings.enableLanguageFeature("NewInference")
-                languageSettings.useExperimentalAnnotation(
-                        "kotlinx.coroutines.ExperimentalCoroutinesApi")
             }
         }
     }

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/UploadArtifactTaskBase.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/UploadArtifactTaskBase.kt
@@ -1,6 +1,7 @@
 package com.github.triplet.gradle.play.tasks.internal
 
 import com.android.build.gradle.api.ApplicationVariant
+import com.github.triplet.gradle.common.utils.orNull
 import com.github.triplet.gradle.play.PlayPublisherExtension
 import com.github.triplet.gradle.play.internal.config
 import org.gradle.api.tasks.InputFile
@@ -21,7 +22,7 @@ internal abstract class UploadArtifactTaskBase(
             val customDir = extension.config.artifactDir
 
             return if (customDir == null) {
-                variant.mappingFileProvider.get().singleOrNull()?.takeIf { it.exists() }
+                variant.mappingFileProvider.get().singleOrNull()?.orNull()
             } else {
                 customDir.listFiles().orEmpty().singleOrNull { it.name == "mapping.txt" }
             }

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/UploadArtifactTaskBase.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/UploadArtifactTaskBase.kt
@@ -21,7 +21,7 @@ internal abstract class UploadArtifactTaskBase(
             val customDir = extension.config.artifactDir
 
             return if (customDir == null) {
-                variant.mappingFileProvider.get().singleOrNull()
+                variant.mappingFileProvider.get().singleOrNull()?.takeIf { it.exists() }
             } else {
                 customDir.listFiles().orEmpty().singleOrNull { it.name == "mapping.txt" }
             }

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishBundleIntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishBundleIntegrationTest.kt
@@ -296,6 +296,32 @@ class PublishBundleIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `Build uploads bundle when mapping file does not exist`() {
+        // language=gradle
+        val config = """
+            android.buildTypes.release {
+                shrinkResources true
+                minifyEnabled true
+                proguardFiles(getDefaultProguardFile("proguard-android.txt"))
+            }
+        """
+        val bundle = File(appDir, "build/outputs/bundle/release/app-release.aab")
+        val bundleCopy = File(tempDir.root, "app-release.aab")
+
+        execute(config, "bundleRelease")
+        bundle.copyTo(bundleCopy)
+        execute(config, "clean")
+        bundleCopy.copyTo(bundle)
+        val result = execute(config, "publishReleaseBundle", "-x", "bundleRelease")
+
+        assertThat(result.task(":publishReleaseBundle")).isNotNull()
+        assertThat(result.task(":publishReleaseBundle")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.output).contains("uploadBundle(")
+        assertThat(result.output).contains(".aab")
+        assertThat(result.output).contains("mappingFile=null")
+    }
+
+    @Test
     fun `Build fails by default when upload fails`() {
         // language=gradle
         val config = """


### PR DESCRIPTION
Fixes a failure when invoking `publishMyVariantBundle` with `-x bundleMyVariant`.

Fixes #784.
