### PR TITLE
Forward-port DeprecationLogger usage to Gradle 6.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Validation.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Validation.kt
@@ -5,7 +5,6 @@ import com.github.triplet.gradle.common.validation.validateDebuggability
 import com.github.triplet.gradle.play.PlayPublisherExtension
 import com.github.triplet.gradle.play.PlayPublisherPlugin
 import org.gradle.api.logging.Logging
-import org.gradle.internal.deprecation.DeprecationLogger
 
 internal fun PlayPublisherExtension.validateCreds() {
     val creds = checkNotNull(config.serviceAccountCredentials) {
@@ -24,11 +23,11 @@ internal fun PlayPublisherExtension.validateCreds() {
         check(config.serviceAccountEmail != null) {
             "PKCS12 credentials must specify a service account email."
         }
-        DeprecationLogger.deprecate("Gradle Play Publisher's PKCS12 based authentication")
-                .withAdvice("Use JSON based authentication instead.")
-                .withContext("https://github.com/Triple-T/gradle-play-publisher#service-account")
-                .undocumented()
-                .nagUser()
+        Logging.getLogger(PlayPublisherPlugin::class.java)
+                .warn("Gradle Play Publisher's PKCS12 based authentication is deprecated.\n" +
+                      "This is scheduled to be removed in GPP 3.0.\n" +
+                      "Please use JSON based authentication instead.\n" +
+                      "https://github.com/Triple-T/gradle-play-publisher#service-account.")
     }
 }
 

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/PlayPublisherPluginIntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/PlayPublisherPluginIntegrationTest.kt
@@ -150,7 +150,7 @@ class PlayPublisherPluginIntegrationTest : IntegrationTestBase() {
             withArguments("help", "--warning-mode", "all")
         }
 
-        assertThat(result.output).contains("PKCS12 based authentication has been deprecated")
+        assertThat(result.output).contains("PKCS12 based authentication is deprecated")
     }
 
     @Test


### PR DESCRIPTION
Fixes #797

Gradle 6.3 contains this PR https://github.com/gradle/gradle/pull/12265

It requires deprecation messages to specify when they will go away using a new API

Please note that I have not searched through the entire project here to see if DeprecationLogger is used in other places. It may be. This is the one from the stack my project through

[Edited: the PR was changed based on feedback to use the regular logger, so will be backwards- + forwards-compatible with gradle versions now]

Hopefully it's useful!