### PR TITLE
Fix: Readme maven repository url

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ available from
 buildscript {
     repositories {
         // ...
-        maven("https://oss.sonatype.org/content/repositories/snapshots")
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 
     dependencies {


### PR DESCRIPTION
This PR should fix an issue with the README.

Prevent error:
```
> Could not find method maven() for arguments [https://oss.sonatype.org/content/repositories/snapshots] on repository container of type org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler.
```

I hope the changes will suit you. Thanks a lot!
