### PR TITLE
Create new extension and fill it with config instead of overriding

### DIFF
--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
@@ -14,6 +14,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
+import java.util.*
 
 internal val ApplicationVariantProperties.flavorNameOrDefault
     get() = flavorName.nullOrFull() ?: "main"
@@ -74,7 +75,10 @@ private fun buildExtensionInternal(
     }.singleOrNull()
     val buildTypeExtension = variant.buildType?.let { extensionContainer.findByName(it) }
 
+    val result = extensionContainer.create(UUID.randomUUID().toString())
+
     val extensions = listOfNotNull(
+            result,
             cliOptionsExtension,
             variantExtension,
             flavorExtension,


### PR DESCRIPTION
A shitty hack i made to make #842 work.

Problem seems to be that `mergeExtensions` always modifies the first entry in the list and returns it, but that means the last call in `android.onVariants` will become the common extension for all variants when any task is actually run.