### PR TITLE
Upload all bundle files in the artifacts directory

### DIFF
--- a/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/EditManager.kt
+++ b/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/EditManager.kt
@@ -67,26 +67,13 @@ interface EditManager {
             retainableArtifacts: List<Long>?
     )
 
-    /** Uploads and publishes the given [bundleFile]. */
+    /** Uploads the given [bundleFile]. */
     fun uploadBundle(
             bundleFile: File,
-            strategy: ResolutionStrategy,
-            didPreviousBuildSkipCommit: Boolean,
-            trackName: String,
-            releaseStatus: ReleaseStatus?,
-            releaseName: String?,
-            releaseNotes: Map</* locale= */String, /* text= */String?>?,
-            userFraction: Double?,
-            updatePriority: Int?,
-            retainableArtifacts: List<Long>?
-    )
+            strategy: ResolutionStrategy
+    ) : Long?
 
-    /**
-     * Uploads the given [apkFile].
-     *
-     * Note: since APKs have splits, APK management is a two step process. The APKs must first be
-     * uploaded and then published using [publishApk].
-     */
+    /** Uploads the given [apkFile]. */
     fun uploadApk(
             apkFile: File,
             mappingFile: File?,
@@ -96,8 +83,8 @@ interface EditManager {
             patchObbRetainable: Int?
     ): Long?
 
-    /** Publishes a set of APKs uploaded with [uploadApk]. */
-    fun publishApk(
+    /** Publishes artifacts specified by given [versionCodes] */
+    fun publishArtifacts(
             versionCodes: List<Long>,
             didPreviousBuildSkipCommit: Boolean,
             trackName: String,

--- a/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/internal/DefaultEditManager.kt
+++ b/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/internal/DefaultEditManager.kt
@@ -127,35 +127,16 @@ internal class DefaultEditManager(
 
     override fun uploadBundle(
             bundleFile: File,
-            strategy: ResolutionStrategy,
-            didPreviousBuildSkipCommit: Boolean,
-            trackName: String,
-            releaseStatus: ReleaseStatus?,
-            releaseName: String?,
-            releaseNotes: Map<String, String?>?,
-            userFraction: Double?,
-            updatePriority: Int?,
-            retainableArtifacts: List<Long>?
-    ) {
+            strategy: ResolutionStrategy
+    ): Long? {
         val bundle = try {
             publisher.uploadBundle(editId, bundleFile)
         } catch (e: GoogleJsonResponseException) {
             handleUploadFailures(e, strategy, bundleFile)
-        } ?: return
+            return null
+        }
 
-        tracks.update(TrackManager.UpdateConfig(
-                trackName,
-                listOf(bundle.versionCode.toLong()),
-                didPreviousBuildSkipCommit,
-                TrackManager.BaseConfig(
-                        releaseStatus,
-                        userFraction,
-                        updatePriority,
-                        releaseNotes,
-                        retainableArtifacts,
-                        releaseName
-                )
-        ))
+        return bundle.versionCode.toLong()
     }
 
     override fun uploadApk(
@@ -185,7 +166,7 @@ internal class DefaultEditManager(
         return apk.versionCode.toLong()
     }
 
-    override fun publishApk(
+    override fun publishArtifacts(
             versionCodes: List<Long>,
             didPreviousBuildSkipCommit: Boolean,
             trackName: String,

--- a/play/android-publisher/src/test/kotlin/com/github/triplet/gradle/androidpublisher/internal/DefaultEditManagerTest.kt
+++ b/play/android-publisher/src/test/kotlin/com/github/triplet/gradle/androidpublisher/internal/DefaultEditManagerTest.kt
@@ -34,37 +34,18 @@ class DefaultEditManagerTest {
     private var mockFile = mock(File::class.java)
 
     @Test
-    fun `uploadBundle forwards config to track manager`() {
+    fun `uploadBundle doesn't update tracks`() {
         `when`(mockPublisher.uploadBundle(any(), any())).thenReturn(Bundle().apply {
             versionCode = 888
         })
 
-        edits.uploadBundle(
+        val versionCode = edits.uploadBundle(
                 bundleFile = mockFile,
-                strategy = ResolutionStrategy.FAIL,
-                didPreviousBuildSkipCommit = false,
-                trackName = "alpha",
-                releaseStatus = ReleaseStatus.COMPLETED,
-                releaseName = "relname",
-                releaseNotes = mapOf("locale" to "notes"),
-                userFraction = .88,
-                updatePriority = 3,
-                retainableArtifacts = listOf(777)
+                strategy = ResolutionStrategy.FAIL
         )
 
-        verify(mockTracks).update(TrackManager.UpdateConfig(
-                trackName = "alpha",
-                versionCodes = listOf(888L),
-                didPreviousBuildSkipCommit = false,
-                base = TrackManager.BaseConfig(
-                        releaseStatus = ReleaseStatus.COMPLETED,
-                        releaseName = "relname",
-                        releaseNotes = mapOf("locale" to "notes"),
-                        userFraction = .88,
-                        updatePriority = 3,
-                        retainableArtifacts = listOf(777)
-                )
-        ))
+        verify(mockTracks, never()).update(any())
+        assertThat(versionCode).isEqualTo(888)
     }
 
     @Test
@@ -75,15 +56,7 @@ class DefaultEditManagerTest {
 
         edits.uploadBundle(
                 bundleFile = mockFile,
-                strategy = ResolutionStrategy.IGNORE,
-                didPreviousBuildSkipCommit = false,
-                trackName = "alpha",
-                releaseStatus = ReleaseStatus.COMPLETED,
-                releaseName = "relname",
-                releaseNotes = mapOf("locale" to "notes"),
-                userFraction = .88,
-                updatePriority = 3,
-                retainableArtifacts = listOf(777)
+                strategy = ResolutionStrategy.IGNORE
         )
 
         verify(mockTracks, never()).update(any())
@@ -98,15 +71,7 @@ class DefaultEditManagerTest {
         assertThrows<IllegalStateException> {
             edits.uploadBundle(
                     bundleFile = mockFile,
-                    strategy = ResolutionStrategy.FAIL,
-                    didPreviousBuildSkipCommit = false,
-                    trackName = "alpha",
-                    releaseStatus = ReleaseStatus.COMPLETED,
-                    releaseName = "relname",
-                    releaseNotes = mapOf("locale" to "notes"),
-                    userFraction = .88,
-                    updatePriority = 3,
-                    retainableArtifacts = listOf(777)
+                    strategy = ResolutionStrategy.FAIL
             )
         }
     }
@@ -282,8 +247,8 @@ class DefaultEditManagerTest {
     }
 
     @Test
-    fun `publishApk ignores empty version codes`() {
-        edits.publishApk(
+    fun `publishArtifacts ignores empty version codes`() {
+        edits.publishArtifacts(
                 versionCodes = emptyList(),
                 didPreviousBuildSkipCommit = false,
                 trackName = "alpha",
@@ -299,8 +264,8 @@ class DefaultEditManagerTest {
     }
 
     @Test
-    fun `publishApk forwards config to track manager`() {
-        edits.publishApk(
+    fun `publishArtifacts forwards config to track manager`() {
+        edits.publishArtifacts(
                 versionCodes = listOf(888L),
                 didPreviousBuildSkipCommit = false,
                 trackName = "alpha",

--- a/play/android-publisher/src/testFixtures/kotlin/com/github/triplet/gradle/androidpublisher/FakeEditManager.kt
+++ b/play/android-publisher/src/testFixtures/kotlin/com/github/triplet/gradle/androidpublisher/FakeEditManager.kt
@@ -56,16 +56,8 @@ abstract class FakeEditManager : EditManager {
 
     override fun uploadBundle(
             bundleFile: File,
-            strategy: ResolutionStrategy,
-            didPreviousBuildSkipCommit: Boolean,
-            trackName: String,
-            releaseStatus: ReleaseStatus?,
-            releaseName: String?,
-            releaseNotes: Map<String, String?>?,
-            userFraction: Double?,
-            updatePriority: Int?,
-            retainableArtifacts: List<Long>?
-    ): Unit = throw IllegalStateException("Test wasn't expecting this method to be called.")
+            strategy: ResolutionStrategy
+    ): Long? = throw IllegalStateException("Test wasn't expecting this method to be called.")
 
     override fun uploadApk(
             apkFile: File,
@@ -76,7 +68,7 @@ abstract class FakeEditManager : EditManager {
             patchObbRetainable: Int?
     ): Long? = throw IllegalStateException("Test wasn't expecting this method to be called.")
 
-    override fun publishApk(
+    override fun publishArtifacts(
             versionCodes: List<Long>,
             didPreviousBuildSkipCommit: Boolean,
             trackName: String,

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -44,7 +44,6 @@ import com.github.triplet.gradle.play.tasks.internal.WriteTrackLifecycleTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.file.RegularFile
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Provider
 import org.gradle.api.publish.plugins.PublishingPlugin

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishApk.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishApk.kt
@@ -89,7 +89,7 @@ internal abstract class PublishApk @Inject constructor(
             val versions = parameters.uploadResults.asFileTree.map {
                 it.name.toLong()
             }.sorted()
-            apiService.edits.publishApk(
+            apiService.edits.publishArtifacts(
                     versions,
                     apiService.shouldSkip(),
                     config.track,

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishInternalSharingBundle.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishInternalSharingBundle.kt
@@ -4,36 +4,62 @@ import com.github.triplet.gradle.play.PlayPublisherExtension
 import com.github.triplet.gradle.play.tasks.internal.ArtifactExtensionOptions
 import com.github.triplet.gradle.play.tasks.internal.PublishTaskBase
 import com.github.triplet.gradle.play.tasks.internal.workers.PlayWorkerBase
+import com.github.triplet.gradle.play.tasks.internal.workers.copy
 import com.github.triplet.gradle.play.tasks.internal.workers.paramsForBase
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.InputFile
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.submit
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.workers.WorkerExecutor
+import java.io.File
 import javax.inject.Inject
 
 internal abstract class PublishInternalSharingBundle @Inject constructor(
         extension: PlayPublisherExtension
 ) : PublishTaskBase(extension), ArtifactExtensionOptions {
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    @get:InputFile
-    internal abstract val bundle: RegularFileProperty
+    @get:SkipWhenEmpty
+    @get:InputFiles
+    internal abstract val bundles: ConfigurableFileCollection
 
     @get:OutputDirectory
     abstract val outputDirectory: DirectoryProperty
 
     @TaskAction
     fun publishBundle() {
-        project.serviceOf<WorkerExecutor>().noIsolation().submit(BundleUploader::class) {
+        project.serviceOf<WorkerExecutor>().noIsolation().submit(Processor::class) {
             paramsForBase(this)
 
-            bundleFile.set(bundle)
+            bundleFiles.set(bundles)
             outputDir.set(outputDirectory)
+        }
+    }
+
+    abstract class Processor @Inject constructor(
+            private val executor: WorkerExecutor
+    ) : PlayWorkerBase<Processor.Params>() {
+        override fun execute() {
+            for (bundle in parameters.bundleFiles.get()) {
+                executor.noIsolation().submit(BundleUploader::class) {
+                    parameters.copy(this)
+
+                    bundleFile.set(bundle)
+                    outputDir.set(parameters.outputDir)
+                }
+            }
+        }
+
+        interface Params : PlayPublishingParams {
+            val bundleFiles: ListProperty<File>
+            val outputDir: DirectoryProperty
         }
     }
 

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishApkIntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishApkIntegrationTest.kt
@@ -42,7 +42,7 @@ class PublishApkIntegrationTest : IntegrationTestBase(), ArtifactIntegrationTest
         result.requireTask(":packageRelease", outcome = SUCCESS)
         assertThat(result.output).contains("uploadApk(")
         assertThat(result.output).contains(".apk")
-        assertThat(result.output).contains("publishApk(")
+        assertThat(result.output).contains("publishArtifacts(")
     }
 
     @Test
@@ -203,7 +203,7 @@ class PublishApkIntegrationTest : IntegrationTestBase(), ArtifactIntegrationTest
         result.requireTask(outcome = SUCCESS)
         assertThat(result.output).contains("uploadApk(")
         assertThat(result.output).contains("Soft failure")
-        assertThat(result.output).contains("publishApk(versionCodes=[]")
+        assertThat(result.output).contains("publishArtifacts(versionCodes=[]")
     }
 
     @Test
@@ -242,7 +242,7 @@ class PublishApkIntegrationTest : IntegrationTestBase(), ArtifactIntegrationTest
         assertThat(result.output).contains("app-xxxhdpi")
         assertThat(result.output).contains("app-xxhdpi")
         assertThat(result.output.split("\n").filter {
-            it.contains("publishApk(")
+            it.contains("publishArtifacts(")
         }).hasSize(1)
         assertThat(result.output).contains("versionCodes=[1, 2, 3]")
     }
@@ -340,7 +340,7 @@ class PublishApkIntegrationTest : IntegrationTestBase(), ArtifactIntegrationTest
                     return versionCodes[index]
                 }
 
-                override fun publishApk(
+                override fun publishArtifacts(
                         versionCodes: List<Long>,
                         didPreviousBuildSkipCommit: Boolean,
                         trackName: String,
@@ -351,7 +351,7 @@ class PublishApkIntegrationTest : IntegrationTestBase(), ArtifactIntegrationTest
                         updatePriority: Int?,
                         retainableArtifacts: List<Long>?
                 ) {
-                    println("publishApk(" +
+                    println("publishArtifacts(" +
                                     "versionCodes=$versionCodes, " +
                                     "didPreviousBuildSkipCommit=$didPreviousBuildSkipCommit, " +
                                     "trackName=$trackName, " +

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishApkIntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishApkIntegrationTest.kt
@@ -160,21 +160,6 @@ class PublishApkIntegrationTest : IntegrationTestBase(), ArtifactIntegrationTest
     }
 
     @Test
-    fun `Build doesn't publish APKs when no uploads succeeded`() {
-        // language=gradle
-        val config = """
-            System.setProperty("SOFT_FAIL", "true")
-        """
-
-        val result = execute(config, "publishReleaseApk")
-
-        result.requireTask(outcome = SUCCESS)
-        assertThat(result.output).contains("uploadApk(")
-        assertThat(result.output).contains("Soft failure")
-        assertThat(result.output).contains("publishArtifacts(versionCodes=[]")
-    }
-
-    @Test
     fun `Build uploads multiple APKs when splits are used`() {
         // language=gradle
         val config = """
@@ -213,20 +198,6 @@ class PublishApkIntegrationTest : IntegrationTestBase(), ArtifactIntegrationTest
             it.contains("publishArtifacts(")
         }).hasSize(1)
         assertThat(result.output).contains("versionCodes=[1, 2, 3]")
-    }
-
-    @Test
-    fun `Build uses correct version code`() {
-        // language=gradle
-        val config = """
-            System.setProperty("VERSION_CODES", "8")
-        """
-
-        val result = execute(config, "publishReleaseApk")
-
-        result.requireTask(outcome = SUCCESS)
-        assertThat(result.output).contains("uploadApk(")
-        assertThat(result.output).contains("versionCodes=[8]")
     }
 
     @Test

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishBundleIntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishBundleIntegrationTest.kt
@@ -6,6 +6,7 @@ import com.github.triplet.gradle.androidpublisher.FakePlayPublisher
 import com.github.triplet.gradle.androidpublisher.ReleaseStatus
 import com.github.triplet.gradle.androidpublisher.ResolutionStrategy
 import com.github.triplet.gradle.androidpublisher.newSuccessEditResponse
+import com.github.triplet.gradle.common.utils.nullOrFull
 import com.github.triplet.gradle.common.utils.safeCreateNewFile
 import com.github.triplet.gradle.play.helpers.IntegrationTestBase
 import com.github.triplet.gradle.play.tasks.shared.ArtifactIntegrationTests
@@ -13,10 +14,11 @@ import com.github.triplet.gradle.play.tasks.shared.PublishArtifactIntegrationTes
 import com.github.triplet.gradle.play.tasks.shared.PublishOrPromoteArtifactIntegrationTests
 import com.google.common.truth.Truth.assertThat
 import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.TaskOutcome.FAILED
+import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.junit.jupiter.api.Test
 import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
 
 class PublishBundleIntegrationTest : IntegrationTestBase(), ArtifactIntegrationTests,
         PublishOrPromoteArtifactIntegrationTests, PublishArtifactIntegrationTests {
@@ -51,15 +53,14 @@ class PublishBundleIntegrationTest : IntegrationTestBase(), ArtifactIntegrationT
             }
         """
 
-        val result = executeExpectingFailure(config, "publishReleaseBundle")
+        val result = execute(config, "publishReleaseBundle")
 
-        result.requireTask(outcome = FAILED)
-        assertThat(result.output).contains("ERROR_no-unique-aab-found")
-        assertThat(result.output).contains(playgroundDir.name)
+        assertThat(result.task(":packageRelease")).isNull()
+        result.requireTask(outcome = TaskOutcome.NO_SOURCE)
     }
 
     @Test
-    fun `Using custom artifact with multiple bundles fails build with warning`() {
+    fun `Using custom artifact with multiple bundles uploads each one`() {
         // language=gradle
         val config = """
             play {
@@ -69,11 +70,11 @@ class PublishBundleIntegrationTest : IntegrationTestBase(), ArtifactIntegrationT
 
         File(playgroundDir, "1.aab").safeCreateNewFile()
         File(playgroundDir, "2.aab").safeCreateNewFile()
-        val result = executeExpectingFailure(config, "publishReleaseBundle")
+        val result = execute(config, "publishReleaseBundle")
 
-        result.requireTask(outcome = FAILED)
-        assertThat(result.output).contains("ERROR_no-unique-aab-found")
-        assertThat(result.output).contains(playgroundDir.name)
+        result.requireTask(outcome = SUCCESS)
+        assertThat(result.output).contains("1.aab")
+        assertThat(result.output).contains("2.aab")
     }
 
     companion object {
@@ -99,6 +100,8 @@ class PublishBundleIntegrationTest : IntegrationTestBase(), ArtifactIntegrationT
                 }
             }
             val edits = object : FakeEditManager() {
+                val versionCodeIndex = AtomicInteger()
+
                 override fun findMaxAppVersionCode(): Long {
                     println("findMaxAppVersionCode()")
                     return 123
@@ -106,7 +109,25 @@ class PublishBundleIntegrationTest : IntegrationTestBase(), ArtifactIntegrationT
 
                 override fun uploadBundle(
                         bundleFile: File,
-                        strategy: ResolutionStrategy,
+                        strategy: ResolutionStrategy
+                ) : Long {
+                    println("uploadBundle(" +
+                                    "bundleFile=$bundleFile, " +
+                                    "strategy=$strategy)")
+
+                    if (System.getProperty("FAIL") != null) error("Upload failed")
+
+                    val versionCodes = System.getProperty("VERSION_CODES").nullOrFull().orEmpty()
+                            .replace(" ", "").ifEmpty { "1" }.split(",")
+                            .map { it.toLong() }
+                    val index = versionCodeIndex.getAndUpdate {
+                        (it + 1).coerceAtMost(versionCodes.size - 1)
+                    }
+                    return versionCodes[index]
+                }
+
+                override fun publishArtifacts(
+                        versionCodes: List<Long>,
                         didPreviousBuildSkipCommit: Boolean,
                         trackName: String,
                         releaseStatus: ReleaseStatus?,
@@ -116,9 +137,8 @@ class PublishBundleIntegrationTest : IntegrationTestBase(), ArtifactIntegrationT
                         updatePriority: Int?,
                         retainableArtifacts: List<Long>?
                 ) {
-                    println("uploadBundle(" +
-                                    "bundleFile=$bundleFile, " +
-                                    "strategy=$strategy, " +
+                    println("publishArtifacts(" +
+                                    "versionCodes=$versionCodes, " +
                                     "didPreviousBuildSkipCommit=$didPreviousBuildSkipCommit, " +
                                     "trackName=$trackName, " +
                                     "releaseStatus=$releaseStatus, " +
@@ -127,8 +147,6 @@ class PublishBundleIntegrationTest : IntegrationTestBase(), ArtifactIntegrationT
                                     "userFraction=$userFraction, " +
                                     "updatePriority=$updatePriority, " +
                                     "retainableArtifacts=$retainableArtifacts)")
-
-                    if (System.getProperty("FAIL") != null) error("Upload failed")
                 }
             }
 

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishBundleIntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishBundleIntegrationTest.kt
@@ -77,12 +77,16 @@ class PublishBundleIntegrationTest : IntegrationTestBase(), ArtifactIntegrationT
                 override fun uploadBundle(
                         bundleFile: File,
                         strategy: ResolutionStrategy
-                ): Long {
+                ): Long? {
                     println("uploadBundle(" +
                                     "bundleFile=$bundleFile, " +
                                     "strategy=$strategy)")
 
                     if (System.getProperty("FAIL") != null) error("Upload failed")
+                    if (System.getProperty("SOFT_FAIL") != null) {
+                        println("Soft failure")
+                        return null
+                    }
 
                     val versionCodes = System.getProperty("VERSION_CODES").nullOrFull().orEmpty()
                             .replace(" ", "").ifEmpty { "1" }.split(",")

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishInternalSharingApkIntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishInternalSharingApkIntegrationTest.kt
@@ -3,14 +3,12 @@ package com.github.triplet.gradle.play.tasks
 import com.github.triplet.gradle.androidpublisher.FakePlayPublisher
 import com.github.triplet.gradle.androidpublisher.UploadInternalSharingArtifactResponse
 import com.github.triplet.gradle.androidpublisher.newUploadInternalSharingArtifactResponse
-import com.github.triplet.gradle.common.utils.safeCreateNewFile
 import com.github.triplet.gradle.play.helpers.IntegrationTestBase
 import com.github.triplet.gradle.play.helpers.SharedIntegrationTest.Companion.DEFAULT_TASK_VARIANT
 import com.github.triplet.gradle.play.tasks.shared.ArtifactIntegrationTests
 import com.github.triplet.gradle.play.tasks.shared.PublishInternalSharingArtifactIntegrationTests
 import com.google.common.truth.Truth.assertThat
 import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.TaskOutcome.NO_SOURCE
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -20,11 +18,13 @@ class PublishInternalSharingApkIntegrationTest : IntegrationTestBase(), Artifact
     override fun taskName(taskVariant: String) =
             ":upload${taskVariant.ifEmpty { DEFAULT_TASK_VARIANT }}PrivateApk"
 
-    override fun customArtifactName() = "foo.apk"
+    override fun customArtifactName(name: String) = "$name.apk"
 
-    override fun assertCustomArtifactResults(result: BuildResult) {
+    override fun assertCustomArtifactResults(result: BuildResult, executed: Boolean) {
         assertThat(result.task(":packageRelease")).isNull()
-        assertThat(result.output).contains("uploadInternalSharingApk(")
+        if (executed) {
+            assertThat(result.output).contains("uploadInternalSharingApk(")
+        }
     }
 
     override fun outputFile() = "build/outputs/internal-sharing/apk/release"
@@ -36,39 +36,6 @@ class PublishInternalSharingApkIntegrationTest : IntegrationTestBase(), Artifact
         result.requireTask(":packageRelease", outcome = SUCCESS)
         assertThat(result.output).contains("uploadInternalSharingApk(")
         assertThat(result.output).contains(".apk")
-    }
-
-    @Test
-    fun `Using non-existent custom artifact skips build`() {
-        // language=gradle
-        val config = """
-            play {
-                artifactDir = file('${playgroundDir.escaped()}')
-            }
-        """
-
-        val result = execute(config, "uploadReleasePrivateApk")
-
-        assertThat(result.task(":packageRelease")).isNull()
-        result.requireTask(outcome = NO_SOURCE)
-    }
-
-    @Test
-    fun `Using custom artifact with multiple APKs uploads each one`() {
-        // language=gradle
-        val config = """
-            play {
-                artifactDir = file('${playgroundDir.escaped()}')
-            }
-        """
-
-        File(playgroundDir, "1.apk").safeCreateNewFile()
-        File(playgroundDir, "2.apk").safeCreateNewFile()
-        val result = execute(config, "uploadReleasePrivateApk")
-
-        result.requireTask(outcome = SUCCESS)
-        assertThat(result.output).contains("1.apk")
-        assertThat(result.output).contains("2.apk")
     }
 
     companion object {


### PR DESCRIPTION
This PR updates `publishBundle` and `uploadPrivateBundle` tasks. When `artifactsDir` is specified, both tasks will now upload all bundle files found in the artifacts directory.

✅ Tests pass
✅ Checked with real project 
✅ Documentation verified (no update needed)

Closes: https://github.com/Triple-T/gradle-play-publisher/issues/914