### PR TITLE
build: automatically keep gradle up to date

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,18 @@
+name: Update Gradle Wrapper
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1
+        with:
+          set-distribution-checksum: false


### PR DESCRIPTION
On the AnkiDroid project, we have integrated [this action](https://github.com/gradle-update/update-gradle-wrapper-action) to automagically keep our gradle up to date, and it partially explains how we got ahead of GPP here with regard to what gradle versions work

I'm happy to try to help here by carrying issues to this repo, e.g. #971 but I think it would be better if the compatible-canary PRs were running here vs just in our repo, so this seemed useful.

We've been using it since September 2020 with success.

Here is an example of it's work in our repo: https://github.com/ankidroid/Anki-Android/pull/9109
Here is where we integrated it: https://github.com/ankidroid/Anki-Android/pull/7182

Our current implementation: https://github.com/ankidroid/Anki-Android/blob/master/.github/workflows/update-gradle-wrapper.yml

I'm not sure about the repo token part, the distributions SHA thing [was important for us](https://github.com/ankidroid/Anki-Android/pull/7288) so I'm proposing it here, but the token part is no longer documented, may not be necessary so I'm not including it