### PR TITLE
Expose `android-publisher` project in the Gradle plugin

### DIFF
--- a/play/plugin/build.gradle.kts
+++ b/play/plugin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":play:android-publisher"))
+    api(project(":play:android-publisher"))
     implementation(project(":common:utils"))
     implementation(project(":common:validation"))
 


### PR DESCRIPTION
Based on the issue https://github.com/Triple-T/gradle-play-publisher/issues/885, applying the Gradle plugin is not enough to be able to fully configure it (at least in conventional plugins).

The reason is there are some necessary APIs in `android-publisher` that are not exposed directly by the Gradle plugin, forcing the consumer to not only apply the Gradle plugin, also the consumer needs to add the `android-publisher` artifact.

With this change that requirement is no longer necessary.
