### PR TITLE
Fixes `CommitEdit` issues when enabling ConfigurationCache

### DIFF
--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
@@ -6,6 +6,7 @@ import com.github.triplet.gradle.common.utils.nullOrFull
 import com.github.triplet.gradle.play.PlayPublisherExtension
 import com.github.triplet.gradle.play.tasks.CommitEdit
 import com.github.triplet.gradle.play.tasks.internal.PlayApiService
+import org.gradle.api.DomainObjectSet
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
@@ -53,7 +54,9 @@ internal fun Project.getCommitEditTask(
 ): TaskProvider<CommitEdit> {
     val taskName = "commitEditFor" + appId.split(".").joinToString("Dot") { it.capitalize() }
     return rootProject.newTask(taskName, allowExisting = true, constructorArgs = arrayOf(extension)) {
+        usesService(api)
         apiService.set(api)
+        onlyIf { !api.get().tasksHasFailed }
     }
 }
 

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
@@ -6,7 +6,6 @@ import com.github.triplet.gradle.common.utils.nullOrFull
 import com.github.triplet.gradle.play.PlayPublisherExtension
 import com.github.triplet.gradle.play.tasks.CommitEdit
 import com.github.triplet.gradle.play.tasks.internal.PlayApiService
-import org.gradle.api.DomainObjectSet
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
@@ -56,7 +55,7 @@ internal fun Project.getCommitEditTask(
     return rootProject.newTask(taskName, allowExisting = true, constructorArgs = arrayOf(extension)) {
         usesService(api)
         apiService.set(api)
-        onlyIf { !api.get().tasksHasFailed }
+        onlyIf { !api.get().buildFailed }
     }
 }
 

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/CommitEdit.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/CommitEdit.kt
@@ -6,26 +6,18 @@ import com.github.triplet.gradle.play.tasks.internal.workers.PlayWorkerBase
 import com.github.triplet.gradle.play.tasks.internal.workers.paramsForBase
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.submit
 import org.gradle.work.DisableCachingByDefault
 import org.gradle.workers.WorkerExecutor
 import javax.inject.Inject
 
-@Suppress("LeakingThis")
 @DisableCachingByDefault
 internal abstract class CommitEdit @Inject constructor(
-        private val gradle: Gradle,
         extension: PlayPublisherExtension,
         private val executor: WorkerExecutor,
 ) : PublishTaskBase(extension) {
-    init {
-        onlyIf {
-            val buildFailed = gradle.taskGraph.allTasks.any { it.state.failure != null }
-            if (buildFailed) apiService.get().cleanup()
-            !buildFailed
-        }
-    }
 
     @TaskAction
     fun commit() {
@@ -36,14 +28,14 @@ internal abstract class CommitEdit @Inject constructor(
 
     abstract class Committer : PlayWorkerBase<Committer.Params>() {
         override fun execute() {
-            if (apiService.shouldCommit()) {
+            if (apiService.shouldCommit) {
                 println("Committing changes")
                 try {
                     apiService.commit()
                 } finally {
                     apiService.cleanup()
                 }
-            } else if (apiService.shouldSkip()) {
+            } else if (apiService.shouldSkip) {
                 println("Changes pending commit")
                 try {
                     apiService.validate()

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishApk.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishApk.kt
@@ -99,7 +99,7 @@ internal abstract class PublishApk @Inject constructor(
             }.sorted()
             apiService.edits.publishArtifacts(
                     versions,
-                    apiService.shouldSkip(),
+                    apiService.shouldSkip,
                     config.track,
                     config.releaseStatus,
                     findReleaseName(config.track),

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishBundle.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishBundle.kt
@@ -76,7 +76,7 @@ internal abstract class PublishBundle @Inject constructor(
             }.sorted()
             apiService.edits.publishArtifacts(
                     versions,
-                    apiService.shouldSkip(),
+                    apiService.shouldSkip,
                     config.track,
                     config.releaseStatus,
                     findReleaseName(config.track),

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayApiService.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayApiService.kt
@@ -83,9 +83,7 @@ internal abstract class PlayApiService @Inject constructor(
     }
 
     override fun onFinish(event: FinishEvent) {
-        if (event is TaskFinishEvent) {
-            buildFailed = buildFailed || (event.result is TaskFailureResult)
-        }
+        buildFailed = buildFailed || event.result is TaskFailureResult
     }
 
     private fun getOrCreateEditId(): String {

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayApiService.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayApiService.kt
@@ -44,9 +44,6 @@ internal abstract class PlayApiService @Inject constructor(
     var buildFailed = false
         private set
 
-    var cleanupAtClose = true
-        get() = field && shouldCommit
-
     fun scheduleCommit() {
         editIdFile.marked("commit").safeCreateNewFile()
     }
@@ -80,7 +77,7 @@ internal abstract class PlayApiService @Inject constructor(
     }
 
     override fun close() {
-        if (cleanupAtClose) {
+        if (shouldCommit) {
             cleanup()
         }
     }

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayApiService.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayApiService.kt
@@ -14,13 +14,17 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
+import org.gradle.tooling.events.FinishEvent
+import org.gradle.tooling.events.OperationCompletionListener
+import org.gradle.tooling.events.task.TaskFailureResult
+import org.gradle.tooling.events.task.TaskFinishEvent
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import javax.inject.Inject
 
 internal abstract class PlayApiService @Inject constructor(
         private val fileOps: FileSystemOperations,
-) : BuildService<PlayApiService.Params> {
+) : BuildService<PlayApiService.Params>, OperationCompletionListener, AutoCloseable {
     val publisher by lazy {
         credentialStream().use {
             PlayPublisher(it, parameters.appId.get())
@@ -37,11 +41,17 @@ internal abstract class PlayApiService @Inject constructor(
     private val editIdFileAndFriends
         get() = listOf(editIdFile, editIdFile.marked("commit"), editIdFile.marked("skipped"))
 
+    var tasksHasFailed = false
+        private set
+
+    var cleanupAtClose = true
+        get() = field && shouldCommit
+
     fun scheduleCommit() {
         editIdFile.marked("commit").safeCreateNewFile()
     }
 
-    fun shouldCommit(): Boolean = editIdFile.marked("commit").exists()
+    val shouldCommit get() = editIdFile.marked("commit").exists()
 
     fun commit() {
         val response = publisher.commitEdit(editId)
@@ -59,7 +69,7 @@ internal abstract class PlayApiService @Inject constructor(
         editIdFile.marked("skipped").safeCreateNewFile()
     }
 
-    fun shouldSkip(): Boolean = editIdFile.marked("skipped").exists()
+    val shouldSkip get() = editIdFile.marked("skipped").exists()
 
     fun validate() {
         publisher.validateEdit(editId)
@@ -67,6 +77,18 @@ internal abstract class PlayApiService @Inject constructor(
 
     fun cleanup() {
         fileOps.delete { delete(editIdFileAndFriends) }
+    }
+
+    override fun close() {
+        if (cleanupAtClose) {
+            cleanup()
+        }
+    }
+
+    override fun onFinish(event: FinishEvent) {
+        if (event is TaskFinishEvent) {
+            tasksHasFailed = tasksHasFailed || (event.result is TaskFailureResult)
+        }
     }
 
     private fun getOrCreateEditId(): String {

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayApiService.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayApiService.kt
@@ -41,7 +41,7 @@ internal abstract class PlayApiService @Inject constructor(
     private val editIdFileAndFriends
         get() = listOf(editIdFile, editIdFile.marked("commit"), editIdFile.marked("skipped"))
 
-    var tasksHasFailed = false
+    var buildFailed = false
         private set
 
     var cleanupAtClose = true
@@ -87,7 +87,7 @@ internal abstract class PlayApiService @Inject constructor(
 
     override fun onFinish(event: FinishEvent) {
         if (event is TaskFinishEvent) {
-            tasksHasFailed = tasksHasFailed || (event.result is TaskFailureResult)
+            buildFailed = buildFailed || (event.result is TaskFailureResult)
         }
     }
 

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/helpers/IntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/helpers/IntegrationTest.kt
@@ -10,6 +10,8 @@ interface IntegrationTest {
 
     val factoryInstallerStatement: String
 
+    val withConfigurationCache: Boolean
+
     fun File.escaped(): String
 
     fun execute(config: String, vararg tasks: String): BuildResult

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/helpers/IntegrationTestBase.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/helpers/IntegrationTestBase.kt
@@ -13,7 +13,9 @@ import java.util.concurrent.BlockingQueue
 import kotlin.math.max
 import kotlin.random.Random
 
-abstract class IntegrationTestBase : IntegrationTest {
+abstract class IntegrationTestBase(
+        override val withConfigurationCache: Boolean = false
+) : IntegrationTest {
     @TempDir
     @JvmField
     var _tempDir: File? = null
@@ -54,9 +56,10 @@ abstract class IntegrationTestBase : IntegrationTest {
                 .withTestKitDir(testDir)
                 .apply(block)
 
-        if (!expectFailure) {
-            runner.withArguments(runner.arguments.toMutableList() + "-S")
-        }
+        runner.withArguments(runner.arguments + listOfNotNull(
+                "-S".takeIf { !expectFailure },
+                "--configuration-cache".takeIf { withConfigurationCache },
+        ))
 
         // We're doing some pretty wack (and disgusting, shameful) shit to run integration tests without
         // actually publishing anything. The idea is have the build file call into the test class to run

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/CommitEditIntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/CommitEditIntegrationTest.kt
@@ -13,7 +13,7 @@ import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.junit.jupiter.api.Test
 import java.io.File
 
-class CommitEditIntegrationTest : IntegrationTestBase(), SharedIntegrationTest {
+class CommitEditIntegrationTest : IntegrationTestBase(withConfigurationCache = true), SharedIntegrationTest {
     override fun taskName(taskVariant: String) = ":commitEditForComDotExampleDotPublisher"
 
     @Test

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/GenerateEditIntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/GenerateEditIntegrationTest.kt
@@ -70,12 +70,12 @@ class GenerateEditIntegrationTest : IntegrationTestBase(), SharedIntegrationTest
             tasks.register("gen") { gen ->
                 def service = gradle.sharedServices.registrations
                             .named("playApi-com.example.publisher")
-                            .get().service.get() as PlayApiService
+                            .get().service
 
-                service.cleanupAtClose = false
+                usesService(service)
 
                 doLast {
-                    service.edits
+                    service.get().edits
                 }
             }
 

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/GenerateEditIntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/GenerateEditIntegrationTest.kt
@@ -72,6 +72,8 @@ class GenerateEditIntegrationTest : IntegrationTestBase(), SharedIntegrationTest
                             .named("playApi-com.example.publisher")
                             .get().service.get() as PlayApiService
 
+                service.cleanupAtClose = false
+
                 doLast {
                     service.edits
                 }

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/shared/PublishArtifactIntegrationTests.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/shared/PublishArtifactIntegrationTests.kt
@@ -63,7 +63,7 @@ interface PublishArtifactIntegrationTests : SharedIntegrationTest {
         // language=gradle
         val config2 = """
             android.defaultConfig.versionCode 2
-            play.commit = true
+            play.commit = false
         """
 
         val result1 = execute(config1, taskName())

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/shared/PublishArtifactIntegrationTests.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/shared/PublishArtifactIntegrationTests.kt
@@ -63,7 +63,7 @@ interface PublishArtifactIntegrationTests : SharedIntegrationTest {
         // language=gradle
         val config2 = """
             android.defaultConfig.versionCode 2
-            play.commit = false
+            play.commit = true
         """
 
         val result1 = execute(config1, taskName())


### PR DESCRIPTION
Follow up PR of https://github.com/Triple-T/gradle-play-publisher/pull/1084 partially addressing #1083 

In order to work con `Gradle 8.1.1` Configuration Cache issues, we need to bump Gradle, AGP to `8.0.0` and set the minimum JDK to 11 (17 for running the tests).
All these changes were done in the first commit. 

Focussing exclusively on `CommitEdit` task, I've made some changes as @ZacSweers suggested but still I didn't manage to get it to work as `onlyIf` seems to be computed at configuration time ([asked in Slack if this is expected, probably will fill an issue](https://gradle-community.slack.com/archives/C013WEPGQF9/p1682304058131779))

Said that, there are still many tests broken if we enable CC for the whole test suite, so being fully compatible with CC is going to be a more complex task. If any is eager to contribute, I've added a `withConfigurationCache` property to `IntegrationTestBase`'s constructor so we can start fixing them incrementally:
```kotlin
class CommitEditIntegrationTest : IntegrationTestBase(withConfigurationCache = true), SharedIntegrationTest
```

Once the migration is done, we can just remove this flag and turn it of by adding the properties into `play/plugin/src/test/fixtures/app/gradle.properties`:
```properties
org.gradle.configuration-cache=true
```

Here is the list of failing tests after this PR (if CC is enabled for all of them):
![image](https://user-images.githubusercontent.com/513566/236421905-f2bf081f-0e69-420c-a683-c2195905ff90.png)
