### PR TITLE
Update play google-api-client 2.2.0 and android-publisher to 2.0.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,7 +39,7 @@ dependencyResolutionManagement {
             version("agp", "8.0.1")
             version("agp-tools", "31.0.1")
             version("android-publisher", "v3-rev20211021-1.32.1")
-            version("api-client", "1.32.2")
+            version("api-client", "2.2.0")
             version("http-client", "1.40.1")
             version("http-auth", "1.2.2")
             version("guava", "31.0.1-jre")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,7 +38,7 @@ dependencyResolutionManagement {
 
             version("agp", "8.0.1")
             version("agp-tools", "31.0.1")
-            version("android-publisher", "v3-rev20211021-1.32.1")
+            version("android-publisher", "v3-rev20230615-2.0.0")
             version("api-client", "2.2.0")
             version("http-client", "1.40.1")
             version("http-auth", "1.2.2")


### PR DESCRIPTION
Fixes https://github.com/Triple-T/gradle-play-publisher/issues/1074

I wanted to updated only the Google API Client, but the original issue was with the `android-publisher` being incompatible with Google API client 2.x.

I was not able to find a changelog for `android-publisher`. I just realized that last release was 2.0 by looking at the source: https://github.com/googleapis/google-api-java-client-services/tree/main/clients/google-api-services-androidpublisher/v3
Not sure how you handle these kinds of updates.

Google API client has an updated changelog instead: https://github.com/googleapis/google-api-java-client/releases.

I was able to integrate it in an existing project and it seems to work. Also, all unit tests pass.