### PR TITLE
Copy release notes from previous release also when it's a staged rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ src/main/play/release-notes/en-US/default.txt
 When you publish to the beta channel, the `beta.txt` release notes will be uploaded. For any other
 channel, `default.txt` will be uploaded.
 
+If no release notes are found, GPP will try to copy release notes from the previous release.
+
 > Note: the Play Store limits your release notes to a maximum of 500 characters.
 
 #### Uploading developer facing release names


### PR DESCRIPTION
This PR updates the logic related to reusing release notes. 

Previously GPP was reusing the latest release notes only in case of a full rollout. Now GPP will reuse the latest release notes also when it's a staged rollout release. 

Discussed here: https://github.com/Triple-T/gradle-play-publisher/issues/763#issuecomment-1787267141

✅ Tests pass
✅ Checked with real project
✅ Documentation updated