### PR TITLE
Shade third-party dependencies in the plugin classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,9 @@
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import io.github.gradlenexus.publishplugin.CloseNexusStagingRepository
-import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import java.time.Duration
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 
 buildscript {
     dependencies {
@@ -61,25 +62,31 @@ allprojects {
     version = versionName
     group = "com.github.triplet.gradle"
 
-    afterEvaluate {
-        extensions.findByType<JavaPluginExtension>()?.apply {
+    plugins.withType<JavaPlugin> {
+        configure<JavaPluginExtension> {
             toolchain.languageVersion.convention(JavaLanguageVersion.of(11))
             withJavadocJar()
             withSourcesJar()
         }
+    }
 
-        extensions.findByType<KotlinProjectExtension>()?.apply {
+    plugins.withType<KotlinPluginWrapper> {
+        configure<KotlinProjectExtension> {
             sourceSets.configureEach {
                 languageSettings.progressiveMode = true
                 languageSettings.enableLanguageFeature("NewInference")
             }
         }
+    }
 
-        extensions.findByType<PublishingExtension>()?.apply {
+    plugins.withType<PublishingPlugin> {
+        configure<PublishingExtension> {
             configureMaven(repositories)
         }
+    }
 
-        extensions.findByType<SigningExtension>()?.apply {
+    plugins.withType<SigningPlugin> {
+        configure<SigningExtension> {
             isRequired = false
 
             useInMemoryPgpKeys(System.getenv("SIGNING_KEY"), System.getenv("SIGNING_PASSWORD"))

--- a/play/android-publisher/build.gradle.kts
+++ b/play/android-publisher/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.gradle.publish.PublishTaskShadowAction
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -5,20 +6,27 @@ plugins {
     `java-test-fixtures`
     `maven-publish`
     signing
+    id("com.github.johnrengelman.shadow")
 }
 
 dependencies {
     implementation(project(":common:utils"))
-    implementation(libs.androidpublisher)
-    implementation(libs.client.api)
-    implementation(libs.client.auth)
-    implementation(libs.client.http)
+    shadowImplementation(libs.androidpublisher)
+    shadowImplementation(libs.client.api)
+    shadowImplementation(libs.client.auth)
+    shadowImplementation(libs.client.http)
 
     testImplementation(testLibs.junit)
     testImplementation(testLibs.junit.engine)
     testImplementation(testLibs.truth)
     testImplementation(testLibs.mockito)
 }
+
+// Normally performed by plugin-publish
+pluginManager.withPlugin(
+    "com.github.johnrengelman.shadow",
+    PublishTaskShadowAction(project, logger)
+)
 
 // Mockito needs to be able to pass in null params
 tasks.named<KotlinCompile>("compileTestKotlin") {

--- a/play/plugin/build.gradle.kts
+++ b/play/plugin/build.gradle.kts
@@ -3,11 +3,12 @@ plugins {
     `kotlin-dsl`
     `maven-publish`
     signing
+    id("com.github.johnrengelman.shadow")
     id("com.gradle.plugin-publish")
 }
 
 dependencies {
-    implementation(project(":play:android-publisher"))
+    implementation(project(":play:android-publisher", "shadow"))
     implementation(project(":common:utils"))
     implementation(project(":common:validation"))
 
@@ -15,8 +16,8 @@ dependencies {
     compileOnly(libs.agp.common)
     compileOnly(libs.agp.test)
     compileOnly(libs.agp.ddms)
-    implementation(libs.guava)
-    implementation(libs.client.gson)
+    shadowImplementation(libs.guava)
+    shadowImplementation(libs.client.gson)
 
     testImplementation(project(":common:utils"))
     testImplementation(project(":common:validation"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,7 @@ dependencyResolutionManagement {
             version("depUpdates", "0.50.0")
             version("gradlePublish", "1.2.1")
             version("nexusPublish", "1.3.0")
+            version("shadow", "8.1.1")
 
             plugin("depUpdates", "com.github.ben-manes.versions")
                 .versionRef("depUpdates")
@@ -35,6 +36,8 @@ dependencyResolutionManagement {
                 .versionRef("gradlePublish")
             plugin("nexusPublish", "io.github.gradle-nexus.publish-plugin")
                 .versionRef("nexusPublish")
+            plugin("shadow", "com.github.johnrengelman.shadow")
+                .versionRef("shadow")
 
             version("agp", "8.2.0")
             version("agp-tools", "31.2.0")

--- a/testapp/build.gradle.kts
+++ b/testapp/build.gradle.kts
@@ -51,11 +51,11 @@ the<JavaPluginExtension>().toolchain.languageVersion.convention(JavaLanguageVers
 
 configure<BaseAppModuleExtension> {
     namespace = "com.supercilex.test"
-    compileSdk = 31
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 31
-        targetSdk = 31
+        targetSdk = 34
         versionCode = 1 // Updated on every build
         versionName = "1.0.0"
     }


### PR DESCRIPTION
Fixes #1091 

At least one other Android-related plugin also puts Google API client libraries on the classpath with conflicting versions; see the linked issue. 

- Apply the [shadow plugin](https://imperceptiblethoughts.com/shadow/introduction/) to `android-publisher` and `play-publisher`.
- Add a `shadowImplementation` configuration, for which dependency classes will be relocated to a package under `com.github.triplet.gradle.shaded`. Move all non-project dependencies from `implementation` to `shadowImplementation`.
- Publishing the shaded jar is configured automatically by `com.gradle.plugin-publish`. As `android-publisher` is not a plugin itself and doesn't apply that plugin in its build, apply `PublishTaskShadowAction` as `plugin-publish` does.
- `testapp`: Bump `compileSdk` and `targetSdk` to 34 so it builds with AGP 8.2.0.

Tested locally by publishing to `mavenLocal` and using it in another project, by running `check` tasks, and by running `testapp:publishBundle` (which fails due to an auth token issue, but otherwise applies the plugin fine).