### PR TITLE
Workaround for colon track names

### DIFF
--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/workers/PublishArtifactWorkerBase.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/workers/PublishArtifactWorkerBase.kt
@@ -22,9 +22,9 @@ internal abstract class PublishArtifactWorkerBase<T : PublishArtifactWorkerBase.
         return if (config.releaseName != null) {
             config.releaseName
         } else if (parameters.consoleNamesDir.isPresent) {
-            val dir = parameters.consoleNamesDir.get()
-            val file = dir.file("$track.txt").asFile.orNull()
-                    ?: dir.file(RELEASE_NAMES_DEFAULT_NAME).asFile.orNull()
+            val dir = parameters.consoleNamesDir.get().asFile
+            val file = File(dir, "$track.txt").orNull()
+                    ?: File(dir, RELEASE_NAMES_DEFAULT_NAME).orNull()
 
             file?.readProcessed()?.lines()?.firstOrNull()
         } else {


### PR DESCRIPTION
Gradle has an [issue](https://github.com/gradle/gradle/issues/862) that `DirectoryProperties.file()` does always resolve file names with colon (`:`) as URI. This breaks when a colon is used as part of a file name.

In this case this is needed for the dedicated PlayStore tracks: tv and wear. They require a corresponding prefix separated by a colon, e.g. "tv:internal". See: developers.google.com/android-publisher/tracks#ff-track-name

Resolving the file paths without `DirectoryProperty.file` does work around this Gradle issue on Plugin side.

Hey there! So you want to contribute to Gradle Play Publisher?
Before you file this pull request, follow these steps:

- Read [the contribution guidelines](https://github.com/Triple-T/gradle-play-publisher/blob/master/CONTRIBUTING.md).
- If this has been discussed in an issue, make sure to mention the issue number here.
  If not, go file an issue about this to make sure it is a desirable change.

Closes #1121 
