### PR TITLE
Use new github action output command

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ buildScan {
 
 tasks.register("configureGithubActions") {
     doLast {
-        println("::set-output name=is_snapshot::$isSnapshotBuild")
+        println("is_snapshot=\"$isSnapshotBuild\" >> $GITHUB_OUTPUT")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ buildScan {
 
 tasks.register("configureGithubActions") {
     doLast {
-        println("is_snapshot=\"$isSnapshotBuild\" >> $GITHUB_OUTPUT")
+        println("is_snapshot=$isSnapshotBuild >> $GITHUB_OUTPUT")
     }
 }
 


### PR DESCRIPTION
I just came across the old usage of defining output.
I changed it.
Honestly, I'm not sure if it works 😅 
But I also have never seen such an setup anyways.. So 🤷 

More info about the deprecation:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/