### PR TITLE
Use new github actions output syntax

### DIFF
--- a/.github/workflows/cid.yml
+++ b/.github/workflows/cid.yml
@@ -23,7 +23,9 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
       - name: Setup environment
         id: setup
-        run: ./gradlew configureGithubActions
+        run: |
+          if grep -qi "snapshot" version.txt; then is_snapshot=true; else is_snapshot=false; fi
+          echo "is_snapshot=$is_snapshot" >> "$GITHUB_OUTPUT"
       - name: Build project
         run: |
           ./gradlew assemble publishToMavenLocal -S

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,12 +24,6 @@ buildScan {
     publishAlways()
 }
 
-tasks.register("configureGithubActions") {
-    doLast {
-        println("::set-output name=is_snapshot::$isSnapshotBuild")
-    }
-}
-
 nexusPublishing {
     repositories {
         sonatype {


### PR DESCRIPTION
Better solution than #1123 🙃 

This time I also tested it on my fork.
See a non-snapshot version run:
https://github.com/StefMa/gradle-play-publisher/actions/runs/8371003805

vs a snapshot version run:
https://github.com/StefMa/gradle-play-publisher/actions/runs/8371010999
This one fails because I can't publish snapshots on the fork.
However, the idea is that the job `deploy_snapshot` runs; and this is what it does.
