### PR TITLE
Run sentry crash reporting plugin on publish

### DIFF
--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -710,6 +710,8 @@ internal abstract class PlayPublisherPlugin @Inject constructor(
             }
         }
         maybeAddDependency("uploadBugsnag${bugsnagName}Mapping")
+
+        maybeAddDependency("uploadSentryProguardMappings$variantName")
     }
 
     // TODO(asaveau): remove after https://github.com/gradle/gradle/issues/12388


### PR DESCRIPTION
Fixes https://github.com/Triple-T/gradle-play-publisher/issues/1128

If present, sets up the sentry proguard mapping upload task (https://github.com/getsentry/sentry-android-gradle-plugin/blob/f9b82ddce3af1a21eec54da8b1c02e36c063939a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt#L114C13-L117C24) as a task dependency.