### PR TITLE
Handle release track names containing a colon

### DIFF
--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/workers/PublishArtifactWorkerBase.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/workers/PublishArtifactWorkerBase.kt
@@ -25,7 +25,6 @@ internal abstract class PublishArtifactWorkerBase<T : PublishArtifactWorkerBase.
             val dir = parameters.consoleNamesDir.get()
             val file = dir.file("${track.replace(':', '-')}.txt").asFile.orNull()
                     ?: dir.file("${track.substringAfter(':')}.txt").asFile.orNull()
-                    ?: dir.file("$track.txt").asFile.orNull()
                     ?: dir.file(RELEASE_NAMES_DEFAULT_NAME).asFile.orNull()
             file?.readProcessed()?.lines()?.firstOrNull()
         } else {
@@ -38,7 +37,6 @@ internal abstract class PublishArtifactWorkerBase<T : PublishArtifactWorkerBase.
         return locales.mapNotNull { locale ->
             File(locale, "${track.replace(':', '-')}.txt").orNull()
                     ?: File(locale, "${track.substringAfter(':')}.txt").orNull()
-                    ?: File(locale, "$track.txt").orNull()
                     ?: File(locale, RELEASE_NOTES_DEFAULT_NAME).orNull()
         }.associate { notes ->
             notes.parentFile.name to notes.readProcessed()

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/workers/PublishArtifactWorkerBase.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/workers/PublishArtifactWorkerBase.kt
@@ -22,10 +22,11 @@ internal abstract class PublishArtifactWorkerBase<T : PublishArtifactWorkerBase.
         return if (config.releaseName != null) {
             config.releaseName
         } else if (parameters.consoleNamesDir.isPresent) {
-            val dir = parameters.consoleNamesDir.get().asFile
-            val file = File(dir, "$track.txt").orNull()
-                    ?: File(dir, RELEASE_NAMES_DEFAULT_NAME).orNull()
-
+            val dir = parameters.consoleNamesDir.get()
+            val file = dir.file("${track.replace(':', '-')}.txt").asFile.orNull()
+                    ?: dir.file("${track.substringAfter(':')}.txt").asFile.orNull()
+                    ?: dir.file("$track.txt").asFile.orNull()
+                    ?: dir.file(RELEASE_NAMES_DEFAULT_NAME).asFile.orNull()
             file?.readProcessed()?.lines()?.firstOrNull()
         } else {
             null
@@ -35,9 +36,10 @@ internal abstract class PublishArtifactWorkerBase<T : PublishArtifactWorkerBase.
     protected fun findReleaseNotes(track: String): Map<String, String?> {
         val locales = parameters.releaseNotesDir.orNull?.asFile?.listFiles().orEmpty()
         return locales.mapNotNull { locale ->
-            var result = File(locale, "$track.txt").orNull()
-            if (result == null) result = File(locale, RELEASE_NOTES_DEFAULT_NAME).orNull()
-            result
+            File(locale, "${track.replace(':', '-')}.txt").orNull()
+                    ?: File(locale, "${track.substringAfter(':')}.txt").orNull()
+                    ?: File(locale, "$track.txt").orNull()
+                    ?: File(locale, RELEASE_NOTES_DEFAULT_NAME).orNull()
         }.associate { notes ->
             notes.parentFile.name to notes.readProcessed()
         }.toSortedMap()


### PR DESCRIPTION
Handle release track names containing a colon (e.g. wear:alpha) gracefully without crashing.

https://github.com/Triple-T/gradle-play-publisher/issues/1088

For releases named `formfactor:track`, try `formfactor-track.txt` and `track.txt` instead of invalid filename `formfactor:track.txt`

https://github.com/chimbori/gradle-play-publisher/commit/cb5729afa399e1980231af67cf6670647d479915