### PR TITLE
Add Application Default Credentials & Service Account impersonation

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,20 @@ play {
 > the `ANDROID_PUBLISHER_CREDENTIALS` environment variable and don't specify the
 > `serviceAccountCredentials` property.
 
+#### Application Default Credentials
+Alternatively, you can use [Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc)
+(and optionally [Service Account impersonation](https://cloud.google.com/docs/authentication/use-service-account-impersonation))
+instead of specifying a JSON private key file or environment variable:
+
+```kt
+android { ... }
+
+play {
+    useApplicationDefaultCredentials = true
+    impersonateServiceAccount = "account@your-project.iam.gserviceaccount.com" // Optional
+}
+```
+
 ## Task organization
 
 GPP follows the Android Gradle Plugin's (AGP) naming convention: `[action][Variant][Thing]`. For

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ play {
 > `serviceAccountCredentials` property.
 
 #### Application Default Credentials
+
 Alternatively, you can use [Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc)
 (and optionally [Service Account impersonation](https://cloud.google.com/docs/authentication/use-service-account-impersonation))
 instead of specifying a JSON private key file or environment variable:

--- a/README.md
+++ b/README.md
@@ -219,6 +219,9 @@ play {
 }
 ```
 
+> Note: Currently [Service Account impersonation](https://cloud.google.com/docs/authentication/use-service-account-impersonation)
+is only supported when using [Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc)
+
 ## Task organization
 
 GPP follows the Android Gradle Plugin's (AGP) naming convention: `[action][Variant][Thing]`. For

--- a/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/PlayPublisher.kt
+++ b/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/PlayPublisher.kt
@@ -119,6 +119,16 @@ interface PlayPublisher {
                 credentials: InputStream,
                 appId: String,
         ): PlayPublisher
+
+        /**
+         * Creates a new [PlayPublisher] using ApplicationDefaultCredentials.
+         *
+         * @param appId the app's package name
+         */
+        fun create(
+                appId: String,
+                impersonateServiceAccount: String?
+        ): PlayPublisher
     }
 
     companion object {
@@ -131,5 +141,15 @@ interface PlayPublisher {
                 appId: String,
         ): PlayPublisher = ServiceLoader.load(Factory::class.java).last()
                 .create(credentials, appId)
+
+        /** Creates a new [PlayPublisher] using Application Default Credentials on GCP
+         *  and using Service Account Impersonation if a Service Account to impersonate is
+         *  configured.
+         * */
+        operator fun invoke(
+                appId: String,
+                impersonateServiceAccount: String?
+        ): PlayPublisher = ServiceLoader.load(Factory::class.java).last()
+                .create(appId, impersonateServiceAccount)
     }
 }

--- a/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/PlayPublisher.kt
+++ b/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/PlayPublisher.kt
@@ -142,10 +142,11 @@ interface PlayPublisher {
         ): PlayPublisher = ServiceLoader.load(Factory::class.java).last()
                 .create(credentials, appId)
 
-        /** Creates a new [PlayPublisher] using Application Default Credentials on GCP
-         *  and using Service Account Impersonation if a Service Account to impersonate is
-         *  configured.
-         * */
+        /**
+         * Creates a new [PlayPublisher] using Application Default Credentials on GCP
+         * and using Service Account Impersonation if a Service Account to impersonate is
+         * configured.
+         */
         operator fun invoke(
                 appId: String,
                 impersonateServiceAccount: String?

--- a/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/internal/AndroidPublisher.kt
+++ b/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/internal/AndroidPublisher.kt
@@ -14,6 +14,7 @@ import com.google.api.services.androidpublisher.AndroidPublisher
 import com.google.api.services.androidpublisher.AndroidPublisherScopes
 import com.google.auth.http.HttpCredentialsAdapter
 import com.google.auth.oauth2.GoogleCredentials
+import com.google.auth.oauth2.ImpersonatedCredentials
 import org.apache.http.auth.AuthScope
 import org.apache.http.auth.UsernamePasswordCredentials
 import org.apache.http.impl.client.BasicCredentialsProvider
@@ -39,6 +40,30 @@ internal fun createPublisher(credentials: InputStream): AndroidPublisher {
             transport,
             GsonFactory.getDefaultInstance(),
             AndroidPublisherAdapter(credential)
+    ).setApplicationName(PLUGIN_NAME).build()
+}
+
+internal fun createPublisher(impersonateServiceAccount: String?): AndroidPublisher {
+    val transport = buildTransport()
+
+    val appDefaultCreds = GoogleCredentials.getApplicationDefault()
+
+    val credential = if (impersonateServiceAccount != null) {
+        ImpersonatedCredentials.newBuilder()
+                .setSourceCredentials(appDefaultCreds)
+                .setTargetPrincipal(impersonateServiceAccount)
+                .setScopes(listOf(AndroidPublisherScopes.ANDROIDPUBLISHER))
+                .setLifetime(300)
+                .setDelegates(null)
+                .build()
+    } else {
+        appDefaultCreds
+    }
+
+    return AndroidPublisher.Builder(
+            transport,
+            GsonFactory.getDefaultInstance(),
+            AndroidPublisherAdapter(credential as GoogleCredentials)
     ).setApplicationName(PLUGIN_NAME).build()
 }
 

--- a/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/internal/AndroidPublisher.kt
+++ b/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/internal/AndroidPublisher.kt
@@ -53,7 +53,6 @@ internal fun createPublisher(impersonateServiceAccount: String?): AndroidPublish
                 .setSourceCredentials(appDefaultCreds)
                 .setTargetPrincipal(impersonateServiceAccount)
                 .setScopes(listOf(AndroidPublisherScopes.ANDROIDPUBLISHER))
-                .setLifetime(300)
                 .setDelegates(null)
                 .build()
     } else {

--- a/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/internal/DefaultPlayPublisher.kt
+++ b/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/internal/DefaultPlayPublisher.kt
@@ -304,6 +304,11 @@ internal class DefaultPlayPublisher(
             val publisher = createPublisher(credentials)
             return DefaultPlayPublisher(publisher, appId)
         }
+
+        override fun create(appId: String, impersonateServiceAccount: String?): PlayPublisher {
+            val publisher = createPublisher(impersonateServiceAccount)
+            return DefaultPlayPublisher(publisher, appId)
+        }
     }
 
     private companion object {

--- a/play/android-publisher/src/testFixtures/kotlin/com/github/triplet/gradle/androidpublisher/FakePlayPublisher.kt
+++ b/play/android-publisher/src/testFixtures/kotlin/com/github/triplet/gradle/androidpublisher/FakePlayPublisher.kt
@@ -46,6 +46,7 @@ abstract class FakePlayPublisher : PlayPublisher {
 
     class Factory : PlayPublisher.Factory {
         override fun create(credentials: InputStream, appId: String) = publisher
+        override fun create(appId: String, impersonateServiceAccount: String?) = publisher
     }
 
     companion object {

--- a/play/plugin/build.gradle.kts
+++ b/play/plugin/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     testImplementation(testLibs.junit.engine)
     testImplementation(testLibs.junit.params)
     testImplementation(testLibs.truth)
+    testImplementation(testLibs.mockito)
 }
 
 tasks.withType<PluginUnderTestMetadata>().configureEach {

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherExtension.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherExtension.kt
@@ -15,6 +15,7 @@ import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.configurationcache.problems.PropertyTrace
 import javax.inject.Inject
 
 /** The entry point for all GPP related configuration. */
@@ -40,6 +41,20 @@ abstract class PlayPublisherExtension @Inject constructor(
     @get:Optional
     @get:InputFile
     abstract val serviceAccountCredentials: RegularFileProperty
+
+    /**
+     * Use GCP Application Default Credentials.
+     */
+    @get:Optional
+    @get:Input
+    abstract val useApplicationDefaultCredentials: Property<Boolean>
+
+    /**
+     * Specify the Service Account to impersonate
+     */
+    @get:Optional
+    @get:Input
+    abstract val impersonateServiceAccount: Property<String>
 
     /**
      * Choose the default packaging method. Either App Bundles or APKs. Affects tasks like

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -47,7 +47,6 @@ import com.github.triplet.gradle.play.tasks.internal.PublishTaskBase
 import com.github.triplet.gradle.play.tasks.internal.PublishableTrackLifecycleTask
 import com.github.triplet.gradle.play.tasks.internal.UpdatableTrackLifecycleTask
 import com.github.triplet.gradle.play.tasks.internal.WriteTrackLifecycleTask
-import org.gradle.api.DomainObjectSet
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -57,15 +56,12 @@ import org.gradle.api.services.BuildServiceRegistration
 import org.gradle.build.event.BuildEventsListenerRegistry
 import org.gradle.kotlin.dsl.container
 import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.domainObjectSet
 import org.gradle.kotlin.dsl.findPlugin
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.invoke
-import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.registerIfAbsent
-import org.gradle.kotlin.dsl.setProperty
 import org.gradle.kotlin.dsl.withType
 import javax.inject.Inject
 
@@ -265,6 +261,8 @@ internal abstract class PlayPublisherPlugin @Inject constructor(
 
                 if (!priorityProp.isPresent || newPriority < priorityProp.get()) {
                     parameters.credentials.set(extension.serviceAccountCredentials)
+                    parameters.useApplicationDefaultCredentials.set(extension.useApplicationDefaultCredentials)
+                    parameters.impersonateServiceAccount.set(extension.impersonateServiceAccount)
                     priorityProp.set(newPriority)
                 }
             }

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayApiService.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayApiService.kt
@@ -17,7 +17,6 @@ import org.gradle.api.services.BuildServiceParameters
 import org.gradle.tooling.events.FinishEvent
 import org.gradle.tooling.events.OperationCompletionListener
 import org.gradle.tooling.events.task.TaskFailureResult
-import org.gradle.tooling.events.task.TaskFinishEvent
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import javax.inject.Inject
@@ -26,8 +25,24 @@ internal abstract class PlayApiService @Inject constructor(
         private val fileOps: FileSystemOperations,
 ) : BuildService<PlayApiService.Params>, OperationCompletionListener, AutoCloseable {
     val publisher by lazy {
-        credentialStream().use {
-            PlayPublisher(it, parameters.appId.get())
+        val useAppDefaultCreds = parameters.useApplicationDefaultCredentials.getOrElse(false)
+        val useExplicitCreds = (parameters.credentials.asFile.orNull != null ||
+                System.getenv(PlayPublisher.CREDENTIAL_ENV_VAR) != null)
+
+        if (useAppDefaultCreds && useExplicitCreds) {
+            error("""
+                |Cannot use both application default credentials and explicit credentials.
+                |Please read our docs for more details:
+                |https://github.com/Triple-T/gradle-play-publisher#authenticating-gradle-play-publisher
+            """.trimMargin())
+        }
+
+        if (useAppDefaultCreds) {
+            PlayPublisher(parameters.appId.get(), parameters.impersonateServiceAccount.getOrNull())
+        } else {
+            credentialStream().use {
+                PlayPublisher(it, parameters.appId.get())
+            }
         }
     }
     val edits by lazy {
@@ -147,6 +162,8 @@ internal abstract class PlayApiService @Inject constructor(
     interface Params : BuildServiceParameters {
         val appId: Property<String>
         val credentials: RegularFileProperty
+        val useApplicationDefaultCredentials: Property<Boolean>
+        val impersonateServiceAccount: Property<String>
         val editIdFile: RegularFileProperty
 
         @Suppress("PropertyName") // Don't use this

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayApiService.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/internal/PlayApiService.kt
@@ -26,12 +26,20 @@ internal abstract class PlayApiService @Inject constructor(
 ) : BuildService<PlayApiService.Params>, OperationCompletionListener, AutoCloseable {
     val publisher by lazy {
         val useAppDefaultCreds = parameters.useApplicationDefaultCredentials.getOrElse(false)
-        val useExplicitCreds = (parameters.credentials.asFile.orNull != null ||
+        val useExplicitCreds = (parameters.credentials.isPresent ||
                 System.getenv(PlayPublisher.CREDENTIAL_ENV_VAR) != null)
 
         if (useAppDefaultCreds && useExplicitCreds) {
             error("""
                 |Cannot use both application default credentials and explicit credentials.
+                |Please read our docs for more details:
+                |https://github.com/Triple-T/gradle-play-publisher#authenticating-gradle-play-publisher
+            """.trimMargin())
+        }
+
+        if (useExplicitCreds && parameters.impersonateServiceAccount.isPresent) {
+            error("""
+                |Service Account impersonation with explicit credentials is currently not supported.
                 |Please read our docs for more details:
                 |https://github.com/Triple-T/gradle-play-publisher#authenticating-gradle-play-publisher
             """.trimMargin())

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/PlayPublisherExtensionTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/PlayPublisherExtensionTest.kt
@@ -158,6 +158,8 @@ class PlayPublisherExtensionTest {
         override val versionCode: Property<Long> get() = project.objects.property()
         override val enabled: Property<Boolean> = project.objects.property()
         override val serviceAccountCredentials: RegularFileProperty = project.objects.fileProperty()
+        override val useApplicationDefaultCredentials: Property<Boolean> = project.objects.property()
+        override val impersonateServiceAccount: Property<String> = project.objects.property()
         override val defaultToAppBundles: Property<Boolean> = project.objects.property()
         override val commit: Property<Boolean> = project.objects.property()
         override val fromTrack: Property<String> = project.objects.property()


### PR DESCRIPTION
## Context

Usage of Service Account keys is [generally discouraged](https://cloud.google.com/iam/docs/best-practices-service-accounts#service-account-keys), with service account [impersonation](https://cloud.google.com/iam/docs/best-practices-service-accounts#choose-when-to-use) being a recommended alternative.

## Changes

Allow [Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc) to be used, and support Service Account impersonation with it. This could be used as an alternative to the existing Service Account key authentication. Since it is an alternative method, it should not affect backwards compatibility.

One point of discussion is the default values used to build `ImpersonatedCredentials` in `AndroidPublisher.kt`. We think these are suitable defaults - hardcoded values for the token lifetime was taken from GCP documentation and seems adequate given that tokens are autogenerated/refreshed by the underlying SDK as HTTP requests are constructed.