### PR TITLE
Add scope to default application credentials

### DIFF
--- a/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/internal/AndroidPublisher.kt
+++ b/play/android-publisher/src/main/kotlin/com/github/triplet/gradle/androidpublisher/internal/AndroidPublisher.kt
@@ -56,7 +56,7 @@ internal fun createPublisher(impersonateServiceAccount: String?): AndroidPublish
                 .setDelegates(null)
                 .build()
     } else {
-        appDefaultCreds
+        appDefaultCreds.createScoped(listOf(AndroidPublisherScopes.ANDROIDPUBLISHER))
     }
 
     return AndroidPublisher.Builder(


### PR DESCRIPTION
[This PR](https://github.com/Triple-T/gradle-play-publisher/pull/1148) added the capability to authenticate with application default credentials.

When the application default credentials are generated using [workload identity federation](https://cloud.google.com/iam/docs/workload-identity-federation) like in a Github action, the generated JSON doesn't contain `scopes`. As a result, the google-auth-library defaults to a scope of `https://www.googleapis.com/auth/cloud-platform`, which doesn't include the androidpublisher scope.

To support all forms of application default credentials (including Identity Pool Credentials), we should specify a scope. Some more info about this is also in https://github.com/googleapis/google-auth-library-java/issues/1274.