### PR TITLE
Isolated Projects fix for Project.getCommitEditTask

### DIFF
--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherExtension.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherExtension.kt
@@ -200,4 +200,15 @@ abstract class PlayPublisherExtension @Inject constructor(
         @get:Input
         abstract val patchObb: Property<Int>
     }
+
+    /**
+     * Enables support for Gradle Isolated Builds.
+     * If your project has multiple subprojects that produce an APK or App Bundle,
+     * then each of them commits an edit to Play separately when this flag is enabled.
+     * The default behaviour is to commit only once at the end.
+     *
+     * Defaults to `false`.
+     */
+    @get:Input
+    abstract val isolatedSingleProject: Property<Boolean>
 }

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -76,6 +76,7 @@ internal abstract class PlayPublisherPlugin @Inject constructor(
             enabled.convention(true)
             defaultToAppBundles.convention(false)
             commit.convention(true)
+            isolatedSingleProject.convention(false)
             track.convention("internal")
             resolutionStrategy.convention(ResolutionStrategy.FAIL)
         }

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Extensions.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Extensions.kt
@@ -26,7 +26,8 @@ internal fun PlayPublisherExtension.toConfig() = PlayExtensionConfig(
         resolutionStrategy.get(),
         retain.artifacts.orNull,
         retain.mainObb.orNull,
-        retain.patchObb.orNull
+        retain.patchObb.orNull,
+        isolatedSingleProject.get(),
 )
 
 internal fun mergeExtensions(extensions: List<ExtensionMergeHolder>): PlayPublisherExtension {
@@ -126,6 +127,7 @@ internal data class PlayExtensionConfig(
         val retainArtifacts: List<Long>?,
         val retainMainObb: Int?,
         val retainPatchObb: Int?,
+        val isolatedSingleProject: Boolean,
 ) : Serializable
 
 internal data class ExtensionMergeHolder(

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/Plugins.kt
@@ -52,7 +52,8 @@ internal fun Project.getCommitEditTask(
         api: Provider<PlayApiService>,
 ): TaskProvider<CommitEdit> {
     val taskName = "commitEditFor" + appId.split(".").joinToString("Dot") { it.capitalize() }
-    return this.newTask(taskName, allowExisting = true, constructorArgs = arrayOf(extension)) {
+    val project = if (extension.isolatedSingleProject.get()) this else rootProject
+    return project.newTask(taskName, allowExisting = true, constructorArgs = arrayOf(extension)) {
         usesService(api)
         apiService.set(api)
         onlyIf { !api.get().buildFailed }

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/PlayPublisherExtensionTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/PlayPublisherExtensionTest.kt
@@ -176,5 +176,6 @@ class PlayPublisherExtensionTest {
             override val mainObb: Property<Int> = project.objects.property()
             override val patchObb: Property<Int> = project.objects.property()
         }
+        override val isolatedSingleProject: Property<Boolean> = project.objects.property()
     }
 }


### PR DESCRIPTION
If this plugin is used in a non-toplevel Gradle project and [Isolated Projects](https://docs.gradle.org/nightly/userguide/isolated_projects.html) (#1144) is enabled, then accessing `rootProject` in `getCommitEditTask` fails.

There doesn't seem to be an obvious reason why the task would need to reside in the root project, so this PR changes it to the calling project.
