### PR TITLE
Fix `MissingValueException` in `publishApk` under configuration cache

### DIFF
--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -51,6 +51,7 @@ import com.github.triplet.gradle.play.tasks.internal.WriteTrackLifecycleTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildServiceRegistration
@@ -212,19 +213,15 @@ internal abstract class PlayPublisherPlugin @Inject constructor(
                 return@v
             }
 
-            fun findApkFiles(): Provider<List<String>> = extension.artifactDir.map {
-                val customDir = it.asFile
-                if (customDir.isFile && customDir.extension == "apk") {
-                    listOf(it.asFile.absolutePath)
+            // #1187: Only return the sources. APKs must be resolved by ApkSpec.resolve()
+            fun findApkFileSources(): Provider<FileCollection> = extension.artifactDir.map { dir ->
+                val file = dir.asFile
+                if (file.isFile && file.extension == "apk") {
+                    project.objects.fileCollection().from(file)
                 } else {
-                    it.asFileTree.matching {
-                        include("*.apk")
-                    }.map { it.absolutePath }
+                    dir.asFileTree.matching { include("*.apk") }
                 }
-            }.orElse(variant.artifacts.get(SingleArtifact.APK).map {
-                variant.artifacts.getBuiltArtifactsLoader().load(it)
-                        ?.elements?.map { it.outputFile }.sneakyNull()
-            })
+            }.orElse(variant.artifacts.get(SingleArtifact.APK).map { it.asFileTree })
 
             fun findBundleFiles(): Provider<List<String>> = extension.artifactDir.map {
                 val customDir = it.asFile
@@ -284,7 +281,9 @@ internal abstract class PlayPublisherPlugin @Inject constructor(
                     arrayOf(extension, executionDir),
             ) {
                 bindApi(api)
-                apks.from(findApkFiles())
+                apkSpec.sources.from(findApkFileSources())
+                apkSpec.artifactDir.set(extension.artifactDir)
+                apkSpec.builtArtifactsLoader.set(variant.artifacts.getBuiltArtifactsLoader())
                 outputDirectory.set(project.layout.buildDirectory.dir(
                         "outputs/internal-sharing/apk/${variant.name}"))
 
@@ -483,7 +482,9 @@ internal abstract class PlayPublisherPlugin @Inject constructor(
                     arrayOf(extension, executionDir),
             ) {
                 configureInputs()
-                apks.from(findApkFiles())
+                apkSpec.sources.from(findApkFileSources())
+                apkSpec.artifactDir.set(extension.artifactDir)
+                apkSpec.builtArtifactsLoader.set(variant.artifacts.getBuiltArtifactsLoader())
                 mappingFiles.from(extension.artifactDir.map { customDir ->
                     project.objects.fileCollection().from(customDir.asFileTree.matching {
                         include("mapping.txt", "*.mapping.txt")

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/ApkSpec.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/internal/ApkSpec.kt
@@ -1,0 +1,34 @@
+package com.github.triplet.gradle.play.internal
+
+import com.android.build.api.variant.BuiltArtifactsLoader
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
+import java.io.File
+
+internal abstract class ApkSpec {
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:SkipWhenEmpty
+    @get:InputFiles
+    abstract val sources: ConfigurableFileCollection
+
+    @get:Internal
+    abstract val artifactDir: DirectoryProperty
+
+    @get:Internal
+    abstract val builtArtifactsLoader: Property<BuiltArtifactsLoader>
+
+    // loader.load() returns null during configuration-cache store
+    // So resolve APKs at task-action time (#1187)
+    fun resolve(): List<File> = if (artifactDir.isPresent) {
+        sources.files.toList()
+    } else {
+        builtArtifactsLoader.get().load(sources)?.elements?.map { File(it.outputFile) }
+                ?: error("output-metadata.json not found in ${sources.asPath}")
+    }
+}

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishApk.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishApk.kt
@@ -2,6 +2,7 @@ package com.github.triplet.gradle.play.tasks
 
 import com.github.triplet.gradle.common.utils.safeCreateNewFile
 import com.github.triplet.gradle.play.PlayPublisherExtension
+import com.github.triplet.gradle.play.internal.ApkSpec
 import com.github.triplet.gradle.play.tasks.internal.CliOptionsImpl
 import com.github.triplet.gradle.play.tasks.internal.PublishArtifactTaskBase
 import com.github.triplet.gradle.play.tasks.internal.PublishableTrackExtensionOptions
@@ -16,6 +17,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
@@ -36,10 +38,8 @@ internal abstract class PublishApk @Inject constructor(
         private val executor: WorkerExecutor,
 ) : PublishArtifactTaskBase(extension),
         PublishableTrackExtensionOptions by CliOptionsImpl(extension, executionDir) {
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    @get:SkipWhenEmpty
-    @get:InputFiles
-    internal abstract val apks: ConfigurableFileCollection
+    @get:Nested
+    internal abstract val apkSpec: ApkSpec
 
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:SkipWhenEmpty
@@ -63,7 +63,7 @@ internal abstract class PublishApk @Inject constructor(
         executor.noIsolation().submit(Processor::class) {
             paramsForBase(this)
 
-            apkFiles.set(apks)
+            apkFiles.set(apkSpec.resolve())
             deobfuscationFiles.from(mappingFiles)
             debugSymbolsFile.set(nativeDebugSymbols)
             uploadResults.set(temporaryDir)

--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishInternalSharingApk.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/tasks/PublishInternalSharingApk.kt
@@ -1,22 +1,19 @@
 package com.github.triplet.gradle.play.tasks
 
 import com.github.triplet.gradle.play.PlayPublisherExtension
+import com.github.triplet.gradle.play.internal.ApkSpec
 import com.github.triplet.gradle.play.tasks.internal.ArtifactExtensionOptions
 import com.github.triplet.gradle.play.tasks.internal.CliOptionsImpl
 import com.github.triplet.gradle.play.tasks.internal.PublishTaskBase
 import com.github.triplet.gradle.play.tasks.internal.workers.PlayWorkerBase
 import com.github.triplet.gradle.play.tasks.internal.workers.copy
 import com.github.triplet.gradle.play.tasks.internal.workers.paramsForBase
-import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
-import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.submit
 import org.gradle.work.DisableCachingByDefault
@@ -31,10 +28,8 @@ internal abstract class PublishInternalSharingApk @Inject constructor(
         private val executor: WorkerExecutor,
 ) : PublishTaskBase(extension),
         ArtifactExtensionOptions by CliOptionsImpl(extension, executionDir) {
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    @get:SkipWhenEmpty
-    @get:InputFiles
-    internal abstract val apks: ConfigurableFileCollection
+    @get:Nested
+    internal abstract val apkSpec: ApkSpec
 
     @get:OutputDirectory
     abstract val outputDirectory: DirectoryProperty
@@ -44,7 +39,7 @@ internal abstract class PublishInternalSharingApk @Inject constructor(
         executor.noIsolation().submit(Processor::class) {
             paramsForBase(this)
 
-            apkFiles.set(apks)
+            apkFiles.set(apkSpec.resolve())
             outputDir.set(outputDirectory)
         }
     }

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/helpers/IntegrationTestBase.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/helpers/IntegrationTestBase.kt
@@ -56,6 +56,9 @@ abstract class IntegrationTestBase(
     override fun executeExpectingFailure(config: String, vararg tasks: String) =
             execute(config, true, *tasks)
 
+    fun execute(config: String, vararg tasks: String, extraArgs: List<String>) =
+            execute(config, false, *tasks, extraArgs = extraArgs)
+
     override fun executeGradle(
             expectFailure: Boolean,
             block: GradleRunner.() -> Unit,
@@ -100,6 +103,7 @@ abstract class IntegrationTestBase(
             config: String,
             expectFailure: Boolean,
             vararg tasks: String,
+            extraArgs: List<String> = emptyList(),
     ): BuildResult {
         val buildCacheDir = File(tempDir, "gradle").escaped()
 
@@ -153,7 +157,7 @@ abstract class IntegrationTestBase(
         """)
 
         return executeGradle(expectFailure) {
-            withArguments("--build-cache", *tasks)
+            withArguments("--build-cache", *extraArgs.toTypedArray(), *tasks)
         }
     }
 

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishApkIntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/tasks/PublishApkIntegrationTest.kt
@@ -51,6 +51,17 @@ class PublishApkIntegrationTest : IntegrationTestBase(), ArtifactIntegrationTest
     }
 
     @Test
+    fun `Builds apk on-the-fly under configuration cache`() {
+        // #1187: Cannot query the value of this provider because it has no value available.
+        val result = execute("", "publishReleaseApk", extraArgs = listOf("--configuration-cache"))
+
+        result.requireTask(":packageRelease", outcome = SUCCESS)
+        assertThat(result.output).contains("uploadApk(")
+        assertThat(result.output).contains(".apk")
+        assertThat(result.output).contains("publishArtifacts(")
+    }
+
+    @Test
     fun `Using custom artifact with single default mapping file uploads it`() {
         // language=gradle
         val config = """


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - Diagnostics and proposed fix
> Significant iterations on the design, driven by myself. Along with removal of verbose comments.

* Fixes #1187

## Cause
`publishApk` failed with `MissingValueException: Cannot query the value of this provider because it has no value available.` on a clean configuration-cache build.

Cause: `BuiltArtifactsLoader.load()` was called before `output-metadata.json` was written, memoizing a `sneakyNull()`

## Solution

This PR defers the `load()` call to the `@TaskAction`, which is run after the `package<Variant>` task is completed.

As requested in [comments](https://github.com/Triple-T/gradle-play-publisher/pull/1189#discussion_r3165264110), a class was used to encapsulate `variant.artifacts.getBuiltArtifactsLoader()` and `extension.artifactDir`, for use in the `@TaskAction`

## Testing

* Integration test added, verified that it failed before this fix

```
mkdir 20850 && cd 20850
git clone https://github.com/ankidroid/Anki-Android.git && cd Anki-Android
git checkout 22fe96c79b80c5db1339fc2104f2048f65ec0118
# MANUAL STEP: setup `AnkiDroid-GCP-Publish-Credentials.json` (see issue) 
GRADLE_USER_HOME=/tmp/fresh-gradle-$$ ./gradlew --stop
GRADLE_USER_HOME=/tmp/fresh-gradle-$$ ./gradlew clean :AnkiDroid:publishPlayReleaseApk -PbuildTime=$(date +%s000) --stacktrace --no-build-cache --no-parallel -Dorg.gradle.configuration-cache.parallel=false -Dorg.gradle.workers.max=1
```