### PR TITLE
Fix Isolated Projects error in Gradle 9.7

### DIFF
--- a/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
+++ b/play/plugin/src/main/kotlin/com/github/triplet/gradle/play/PlayPublisherPlugin.kt
@@ -54,13 +54,11 @@ import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Provider
-import org.gradle.api.services.BuildServiceRegistration
 import org.gradle.build.event.BuildEventsListenerRegistry
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.findPlugin
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.invoke
-import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.registerIfAbsent
 import org.gradle.kotlin.dsl.withType
@@ -252,16 +250,17 @@ internal abstract class PlayPublisherPlugin @Inject constructor(
             }
             buildEventsListenerRegistry.onTaskCompletion(api)
 
-            project.gradle.sharedServices.registrations.named<
-                    BuildServiceRegistration<PlayApiService, PlayApiService.Params>
-                    >("playApi-$appId") {
-                val priorityProp = parameters._extensionPriority
+            // Isolated Projects only permits findByName on the registration container.
+            val apiRegistration = checkNotNull(
+                    project.gradle.sharedServices.registrations.findByName("playApi-$appId"))
+            (apiRegistration.parameters as PlayApiService.Params).run {
+                val priorityProp = _extensionPriority
                 val newPriority = extension.toPriority()
 
                 if (!priorityProp.isPresent || newPriority < priorityProp.get()) {
-                    parameters.credentials.set(extension.serviceAccountCredentials)
-                    parameters.useApplicationDefaultCredentials.set(extension.useApplicationDefaultCredentials)
-                    parameters.impersonateServiceAccount.set(extension.impersonateServiceAccount)
+                    credentials.set(extension.serviceAccountCredentials)
+                    useApplicationDefaultCredentials.set(extension.useApplicationDefaultCredentials)
+                    impersonateServiceAccount.set(extension.impersonateServiceAccount)
                     priorityProp.set(newPriority)
                 }
             }

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/PlayPublisherPluginIntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/PlayPublisherPluginIntegrationTest.kt
@@ -625,6 +625,52 @@ class PlayPublisherPluginIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `Plugin is compatible with isolated projects`() {
+        // language=gradle
+        File(appDir, "settings.gradle").writeText("""
+            dependencyResolutionManagement {
+                repositories {
+                    google()
+                    mavenCentral()
+                }
+            }
+        """)
+
+        // language=gradle
+        File(appDir, "build.gradle").writeText("""
+            plugins {
+                id 'com.android.application'
+                id 'com.github.triplet.play'
+            }
+
+            android {
+                compileSdk 34
+                namespace = "com.example.publisher"
+
+                defaultConfig {
+                    applicationId "com.example.publisher"
+                    minSdk 31
+                    targetSdk 33
+                    versionCode 1
+                    versionName "1.0"
+                }
+            }
+
+            play {
+                serviceAccountCredentials = file('creds.json')
+            }
+        """)
+
+        val result = executeGradle(false) {
+            // Gradle 9.7 is the first version to restrict this API under Isolated Projects.
+            withGradleVersion("9.7.0")
+            withArguments("help", "-Dorg.gradle.isolated-projects=true")
+        }
+
+        assertThat(result.output).doesNotContain("when Isolated Projects is enabled")
+    }
+
+    @Test
     fun `Combination of extensions merges`() {
         // language=gradle
         val config = """

--- a/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/PlayPublisherPluginIntegrationTest.kt
+++ b/play/plugin/src/test/kotlin/com/github/triplet/gradle/play/PlayPublisherPluginIntegrationTest.kt
@@ -661,13 +661,85 @@ class PlayPublisherPluginIntegrationTest : IntegrationTestBase() {
             }
         """)
 
-        val result = executeGradle(false) {
-            // Gradle 9.7 is the first version to restrict this API under Isolated Projects.
-            withGradleVersion("9.7.0")
-            withArguments("help", "-Dorg.gradle.isolated-projects=true")
-        }
+        val result = executeWithIsolatedProjects("help")
 
         assertThat(result.output).doesNotContain("when Isolated Projects is enabled")
+    }
+
+    @Test
+    fun `Plugin is compatible with isolated projects in a subproject`() {
+        val classpathJars = GradleRunner.create().withPluginClasspath().pluginClasspath
+                .joinToString { "'$it'" }
+
+        // language=gradle
+        File(appDir, "settings.gradle").writeText("""
+            dependencyResolutionManagement {
+                repositories {
+                    google()
+                    mavenCentral()
+                }
+            }
+            include(":app")
+        """)
+
+        // language=gradle
+        File(appDir, "build.gradle").writeText("""
+            buildscript {
+                repositories {
+                    google()
+                    gradlePluginPortal {
+                        content {
+                            excludeGroup('com.github.triplet.gradle')
+                        }
+                    }
+                }
+
+                dependencies {
+                    classpath files($classpathJars)
+                    classpath('com.android.tools.build:gradle:9.0.0')
+                }
+            }
+        """)
+
+        val appProjectDir = File(appDir, "app").apply { mkdirs() }
+        File(appDir, "creds.json").copyTo(File(appProjectDir, "creds.json"), overwrite = true)
+
+        // language=gradle
+        File(appProjectDir, "build.gradle").writeText("""
+            plugins {
+                id 'com.android.application'
+                id 'com.github.triplet.play'
+            }
+
+            android {
+                compileSdk 34
+                namespace = "com.example.publisher"
+
+                defaultConfig {
+                    applicationId "com.example.publisher"
+                    minSdk 31
+                    targetSdk 33
+                    versionCode 1
+                    versionName "1.0"
+                }
+            }
+
+            play {
+                serviceAccountCredentials = file('creds.json')
+                isolatedSingleProject = true
+            }
+        """)
+
+        val result = executeWithIsolatedProjects(":app:tasks", "--group", "publishing")
+
+        assertThat(result.output).doesNotContain("when Isolated Projects is enabled")
+        assertThat(result.output).contains("publishApk")
+    }
+
+    private fun executeWithIsolatedProjects(vararg args: String) = executeGradle(false) {
+        // Gradle 9.7 is the first version to restrict this API under Isolated Projects.
+        withGradleVersion("9.7.0")
+        withArguments(*args, "-Dorg.gradle.isolated-projects=true")
     }
 
     @Test


### PR DESCRIPTION
Plugin application fails under Isolated Projects on Gradle 9.7. Gradle forbids named(String, Class, Action) on the build service registration container and permits only findByName(String). The new test pins Gradle 9.7.0 because older versions do not enforce the restriction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)